### PR TITLE
#9: Establish defineConfig and the test seam

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Michael Buss Rønne
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/jsr.json
+++ b/jsr.json
@@ -1,0 +1,19 @@
+{
+  "name": "@readyrun/readyrun",
+  "version": "0.0.0",
+  "exports": {
+    ".": "./src/mod.ts",
+    "./testing": "./src/testing/mod.ts"
+  },
+  "publish": {
+    "include": [
+      "src/**/*.ts",
+      "LICENSE",
+      "README.md",
+      "jsr.json"
+    ],
+    "exclude": [
+      "**/*.test.ts"
+    ]
+  }
+}

--- a/jsr.json
+++ b/jsr.json
@@ -2,8 +2,7 @@
   "name": "@readyrun/readyrun",
   "version": "0.0.0",
   "exports": {
-    ".": "./src/mod.ts",
-    "./testing": "./src/testing/mod.ts"
+    ".": "./src/mod.ts"
   },
   "publish": {
     "include": [
@@ -13,7 +12,8 @@
       "jsr.json"
     ],
     "exclude": [
-      "**/*.test.ts"
+      "**/*.test.ts",
+      "src/testing/**"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    ".": "./src/mod.ts",
-    "./testing": "./src/testing/mod.ts"
+    ".": "./src/mod.ts"
   },
   "files": [
     "src",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@readyrun/readyrun",
+  "version": "0.0.0",
+  "description": "Walk a tracker Frontier and run one coding Worker per Ticket.",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": "./src/mod.ts",
+    "./testing": "./src/testing/mod.ts"
+  },
+  "files": [
+    "src",
+    "LICENSE",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "node --test --experimental-strip-types",
+    "typecheck": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=24"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,39 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: ^24.3.0
+        version: 24.13.3
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+
+packages:
+
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+snapshots:
+
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
+
+  typescript@5.9.3: {}
+
+  undici-types@7.18.2: {}

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -1,0 +1,8 @@
+import {
+  createWorkerAdapter,
+  type WorkerAdapter,
+} from "../worker-adapter.ts";
+
+export function claude(): WorkerAdapter {
+  return createWorkerAdapter();
+}

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -1,0 +1,8 @@
+import {
+  createWorkerAdapter,
+  type WorkerAdapter,
+} from "../worker-adapter.ts";
+
+export function cursor(): WorkerAdapter {
+  return createWorkerAdapter();
+}

--- a/src/adapters/custom.ts
+++ b/src/adapters/custom.ts
@@ -1,0 +1,17 @@
+import {
+  createWorkerAdapter,
+  type WorkerAdapter,
+} from "../worker-adapter.ts";
+import { assertKnownKeys } from "../unknown-keys.ts";
+
+const knownCustomKeys = new Set(["bin", "args"]);
+
+export type CustomWorkerOptions = {
+  bin: string;
+  args?: string[];
+};
+
+export function custom(options: CustomWorkerOptions): WorkerAdapter {
+  assertKnownKeys(options, knownCustomKeys);
+  return Object.assign(createWorkerAdapter(), { options });
+}

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -1,0 +1,26 @@
+import {
+  createTrackerAdapter,
+  type TrackerAdapter,
+} from "../tracker-adapter.ts";
+import { assertKnownKeys } from "../unknown-keys.ts";
+
+const knownGitHubKeys = new Set([
+  "repo",
+  "ready",
+  "labels",
+  "parent",
+  "ids",
+]);
+
+export type GitHubTrackerOptions = {
+  repo: string;
+  ready: "unblocked";
+  labels: string[];
+  parent?: string;
+  ids?: string[];
+};
+
+export function github(options: GitHubTrackerOptions): TrackerAdapter {
+  assertKnownKeys(options, knownGitHubKeys);
+  return Object.assign(createTrackerAdapter(), { options });
+}

--- a/src/adapters/linear.ts
+++ b/src/adapters/linear.ts
@@ -1,0 +1,28 @@
+import {
+  createTrackerAdapter,
+  type TrackerAdapter,
+} from "../tracker-adapter.ts";
+import { assertKnownKeys } from "../unknown-keys.ts";
+
+const knownLinearKeys = new Set([
+  "ready",
+  "state",
+  "label",
+  "project",
+  "parent",
+  "ids",
+]);
+
+export type LinearTrackerOptions = {
+  ready: "unblocked";
+  state?: string;
+  label?: string;
+  project?: string;
+  parent?: string;
+  ids?: string[];
+};
+
+export function linear(options: LinearTrackerOptions): TrackerAdapter {
+  assertKnownKeys(options, knownLinearKeys);
+  return Object.assign(createTrackerAdapter(), { options });
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,33 @@
+import type { TrackerAdapter } from "./tracker-adapter.ts";
+import type { WorkerAdapter } from "./worker-adapter.ts";
+import { assertKnownKeys } from "./unknown-keys.ts";
+
+const knownConfigKeys = new Set([
+  "tracker",
+  "worker",
+  "model",
+  "modelsByLabel",
+  "permissions",
+  "contextFile",
+  "cap",
+]);
+
+export type ReadyRunConfig = {
+  tracker: TrackerAdapter;
+  worker: WorkerAdapter;
+  model: string;
+  modelsByLabel?: Record<string, string>;
+  permissions?: "ask" | "unattended";
+  contextFile?: string;
+  cap?: number;
+};
+
+export function defineConfig<T extends ReadyRunConfig>(config: T): T & {
+  permissions: "ask" | "unattended";
+} {
+  assertKnownKeys(config, knownConfigKeys);
+  return {
+    ...config,
+    permissions: config.permissions ?? "ask",
+  };
+}

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,0 +1,16 @@
+export { defineConfig } from "./config.ts";
+export type { ReadyRunConfig } from "./config.ts";
+export { run, RunCapRequiredError } from "./run.ts";
+export type { RunOptions } from "./run.ts";
+export type { Ticket } from "./ticket.ts";
+export type { TrackerAdapter } from "./tracker-adapter.ts";
+export type { WorkerAdapter } from "./worker-adapter.ts";
+export { UnknownConfigKeyError } from "./unknown-keys.ts";
+export { github } from "./adapters/github.ts";
+export type { GitHubTrackerOptions } from "./adapters/github.ts";
+export { linear } from "./adapters/linear.ts";
+export type { LinearTrackerOptions } from "./adapters/linear.ts";
+export { cursor } from "./adapters/cursor.ts";
+export { claude } from "./adapters/claude.ts";
+export { custom } from "./adapters/custom.ts";
+export type { CustomWorkerOptions } from "./adapters/custom.ts";

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,0 +1,21 @@
+import { defineConfig, type ReadyRunConfig } from "./config.ts";
+
+export type RunOptions = {
+  config: ReadyRunConfig;
+  cap?: number;
+};
+
+export class RunCapRequiredError extends Error {
+  constructor() {
+    super("A Run cannot start without a cap");
+    this.name = "RunCapRequiredError";
+  }
+}
+
+export async function run(options: RunOptions): Promise<void> {
+  const config = defineConfig(options.config);
+  const cap = options.cap ?? config.cap;
+  if (cap === undefined) {
+    throw new RunCapRequiredError();
+  }
+}

--- a/src/testing/memory-tracker.ts
+++ b/src/testing/memory-tracker.ts
@@ -1,0 +1,10 @@
+import { createTrackerAdapter, type TrackerAdapter } from "../tracker-adapter.ts";
+import type { Ticket } from "../ticket.ts";
+
+export type MemoryTrackerOptions = {
+  tickets: Ticket[];
+};
+
+export function memoryTracker(options: MemoryTrackerOptions): TrackerAdapter {
+  return Object.assign(createTrackerAdapter(), { tickets: options.tickets });
+}

--- a/src/testing/mod.ts
+++ b/src/testing/mod.ts
@@ -1,0 +1,7 @@
+export { memoryTracker } from "./memory-tracker.ts";
+export type { MemoryTrackerOptions } from "./memory-tracker.ts";
+export { recordingWorker } from "./recording-worker.ts";
+export type {
+  RecordingWorker,
+  RecordingWorkerOptions,
+} from "./recording-worker.ts";

--- a/src/testing/recording-worker.ts
+++ b/src/testing/recording-worker.ts
@@ -1,0 +1,25 @@
+import { createWorkerAdapter, type WorkerAdapter } from "../worker-adapter.ts";
+
+export type RecordingWorkerOptions = {
+  exitCode?: number;
+};
+
+export type RecordingWorker = WorkerAdapter & {
+  readonly spawns: readonly unknown[];
+  spawn(request: unknown): Promise<{ exitCode: number }>;
+};
+
+export function recordingWorker(
+  options: RecordingWorkerOptions = {},
+): RecordingWorker {
+  const spawns: unknown[] = [];
+  const exitCode = options.exitCode ?? 0;
+
+  return Object.assign(createWorkerAdapter(), {
+    spawns,
+    spawn(request: unknown) {
+      spawns.push(request);
+      return Promise.resolve({ exitCode });
+    },
+  });
+}

--- a/src/ticket.ts
+++ b/src/ticket.ts
@@ -1,0 +1,8 @@
+export type Ticket = {
+  id: string;
+  title: string;
+  body: string;
+  url: string;
+  labels: string[];
+  blockedBy: string[];
+};

--- a/src/tracker-adapter.ts
+++ b/src/tracker-adapter.ts
@@ -1,0 +1,9 @@
+const brand = Symbol("TrackerAdapter");
+
+export type TrackerAdapter = {
+  readonly [brand]: true;
+};
+
+export function createTrackerAdapter(): TrackerAdapter {
+  return { [brand]: true };
+}

--- a/src/unknown-keys.ts
+++ b/src/unknown-keys.ts
@@ -1,0 +1,19 @@
+export class UnknownConfigKeyError extends Error {
+  readonly keys: readonly string[];
+
+  constructor(keys: readonly string[]) {
+    super(`Unknown config key${keys.length === 1 ? "" : "s"}: ${keys.join(", ")}`);
+    this.name = "UnknownConfigKeyError";
+    this.keys = keys;
+  }
+}
+
+export function assertKnownKeys(
+  value: object,
+  known: ReadonlySet<string>,
+): void {
+  const unknown = Object.keys(value).filter((key) => !known.has(key));
+  if (unknown.length > 0) {
+    throw new UnknownConfigKeyError(unknown);
+  }
+}

--- a/src/worker-adapter.ts
+++ b/src/worker-adapter.ts
@@ -1,0 +1,9 @@
+const brand = Symbol("WorkerAdapter");
+
+export type WorkerAdapter = {
+  readonly [brand]: true;
+};
+
+export function createWorkerAdapter(): WorkerAdapter {
+  return { [brand]: true };
+}

--- a/test/define-config.test.ts
+++ b/test/define-config.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { claude, cursor, custom, defineConfig, github, linear, UnknownConfigKeyError } from "../src/mod.ts";
+
+test("a Consumer can assemble defineConfig with typed Tracker Adapter and Worker Adapter factories", () => {
+  const githubConfig = defineConfig({
+    tracker: github({
+      repo: "acme/widgets",
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+    }),
+    worker: cursor(),
+    model: "composer-2",
+  });
+  assert.equal(githubConfig.model, "composer-2");
+
+  const linearConfig = defineConfig({
+    tracker: linear({
+      ready: "unblocked",
+      label: "ready-for-agent",
+    }),
+    worker: claude(),
+    model: "opus",
+  });
+  assert.equal(linearConfig.model, "opus");
+
+  const customConfig = defineConfig({
+    tracker: github({
+      repo: "acme/widgets",
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+    }),
+    worker: custom({ bin: "my-agent" }),
+    model: "local-model",
+  });
+  assert.equal(customConfig.model, "local-model");
+});
+
+test("Permissions default to ask", () => {
+  const config = defineConfig({
+    tracker: github({
+      repo: "acme/widgets",
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+    }),
+    worker: cursor(),
+    model: "composer-2",
+  });
+  assert.equal(config.permissions, "ask");
+});
+
+test("unknown config keys are an error, not ignored", () => {
+  const config = {
+    tracker: github({
+      repo: "acme/widgets",
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+    }),
+    worker: cursor(),
+    model: "composer-2",
+    unknownKnob: true,
+  };
+
+  assert.throws(
+    () => defineConfig(config),
+    (error: unknown) => {
+      assert.ok(error instanceof UnknownConfigKeyError);
+      assert.deepEqual([...error.keys], ["unknownKnob"]);
+      return true;
+    },
+  );
+});
+
+test("unknown keys on a Tracker Adapter factory are an error", () => {
+  const options = {
+    repo: "acme/widgets",
+    ready: "unblocked" as const,
+    labels: ["ready-for-agent"],
+    owner: "acme",
+  };
+
+  assert.throws(
+    () => github(options),
+    (error: unknown) => {
+      assert.ok(error instanceof UnknownConfigKeyError);
+      assert.deepEqual([...error.keys], ["owner"]);
+      return true;
+    },
+  );
+});

--- a/test/run-entry.test.ts
+++ b/test/run-entry.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { defineConfig, run, RunCapRequiredError } from "../src/mod.ts";
+import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
+
+function consumerConfig(overrides: { cap?: number } = {}) {
+  return defineConfig({
+    tracker: memoryTracker({
+      tickets: [
+        {
+          id: "52",
+          title: "Package, defineConfig, and the test seam",
+          body: "Establish the public config surface.",
+          url: "https://github.com/acme/widgets/issues/52",
+          labels: ["ready-for-agent"],
+          blockedBy: [],
+        },
+        {
+          id: "53",
+          title: "Blocked until 52 lands",
+          body: "Depends on the package surface.",
+          url: "https://github.com/acme/widgets/issues/53",
+          labels: ["ready-for-agent"],
+          blockedBy: ["52"],
+        },
+      ],
+    }),
+    worker: recordingWorker({ exitCode: 0 }),
+    model: "composer-2",
+    ...overrides,
+  });
+}
+
+test("tests assemble config with a fake Tracker Adapter and fake Worker Adapter and invoke the same entry the CLI will use", async () => {
+  await run({ config: consumerConfig(), cap: 1 });
+});
+
+test("a Run without a cap is refused", async () => {
+  await assert.rejects(
+    () => run({ config: consumerConfig() }),
+    (error: unknown) => {
+      assert.ok(error instanceof RunCapRequiredError);
+      assert.match(error.message, /A Run cannot start without a cap/);
+      return true;
+    },
+  );
+});
+
+test("a Run accepts a cap supplied in config", async () => {
+  await run({ config: consumerConfig({ cap: 1 }) });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "rootDir": ".",
+    "types": ["node"],
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Why

ReadyRun has no package yet, so later tickets have nothing to test through. The v0 spec puts the seam at the public config surface: a Consumer writes `defineConfig` with Tracker Adapter and Worker Adapter factories, and tests assemble that same object with in-memory fakes then call the same `run()` entry the CLI will use. Without that, every following ticket would invent its own harness.

## What

A JSR-shaped TypeScript library: `defineConfig`, typed factories (`github`, `linear`, `cursor`, `claude`, `custom`), unknown keys rejected, and a Run refused unless a cap is supplied (options or config). Permissions default to `ask`.

## How

In-memory fakes live in `src/testing` for this repo's tests and are not a published export. `run()` validates config and requires a cap; Branch, Worktree, and spawn are #10.

Fixes #9

Made with [Cursor](https://cursor.com)