### PR TITLE
#11: Pick unblocked matching Tickets in stable order

### DIFF
--- a/src/testing/memory-tracker.ts
+++ b/src/testing/memory-tracker.ts
@@ -3,6 +3,10 @@ import type { Ticket } from "../ticket.ts";
 
 export type MemoryTrackerOptions = {
   tickets: Ticket[];
+  ready: "unblocked";
+  labels: string[];
+  parent?: string;
+  ids?: string[];
 };
 
 export function memoryTracker(options: MemoryTrackerOptions): TrackerAdapter {
@@ -10,9 +14,28 @@ export function memoryTracker(options: MemoryTrackerOptions): TrackerAdapter {
   return createTrackerAdapter({
     frontier() {
       return Promise.resolve(
-        options.tickets.filter(
-          (ticket) => ticket.blockedBy.length === 0 && !ineligible.has(ticket.id),
-        ),
+        options.tickets
+          .filter((ticket) => {
+            if (ineligible.has(ticket.id)) {
+              return false;
+            }
+            if (!ticket.blockedBy.every((id) => ineligible.has(id))) {
+              return false;
+            }
+            if (!options.labels.every((label) => ticket.labels.includes(label))) {
+              return false;
+            }
+            if (options.parent !== undefined && ticket.parent !== options.parent) {
+              return false;
+            }
+            if (options.ids !== undefined && !options.ids.includes(ticket.id)) {
+              return false;
+            }
+            return true;
+          })
+          .sort((a, b) =>
+            a.id.localeCompare(b.id, undefined, { numeric: true }),
+          ),
       );
     },
     branchName(ticket) {

--- a/src/ticket.ts
+++ b/src/ticket.ts
@@ -5,4 +5,5 @@ export type Ticket = {
   url: string;
   labels: string[];
   blockedBy: string[];
+  parent?: string;
 };

--- a/test/memory-tracker-contract.test.ts
+++ b/test/memory-tracker-contract.test.ts
@@ -1,0 +1,4 @@
+import { memoryTracker } from "../src/testing/mod.ts";
+import { trackerAdapterContract } from "./tracker-adapter-contract.ts";
+
+trackerAdapterContract("memory Tracker Adapter", memoryTracker);

--- a/test/run-entry.test.ts
+++ b/test/run-entry.test.ts
@@ -27,6 +27,8 @@ function consumerConfig(overrides: { cap?: number } = {}) {
           blockedBy: ["52"],
         },
       ],
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
     }),
     worker: recordingWorker({ exitCode: 0 }),
     model: "composer-2",

--- a/test/run-frontier.test.ts
+++ b/test/run-frontier.test.ts
@@ -1,0 +1,284 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { test } from "node:test";
+import { promisify } from "node:util";
+import { defineConfig, run } from "../src/mod.ts";
+import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
+import { createWorkerAdapter } from "../src/worker-adapter.ts";
+import { ticket } from "./tracker-adapter-contract.ts";
+import { throwawayRepo } from "./throwaway-repo.ts";
+
+const exec = promisify(execFile);
+const silent = { write(_chunk?: string) { return true; } };
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await exec("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+  });
+  return stdout.trim();
+}
+
+test("a blocked Ticket is never picked, even if it matches the selector", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  try {
+    await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [
+            ticket({ id: "52", labels: ["other"] }),
+            ticket({ id: "53", blockedBy: ["52"] }),
+          ],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.deepEqual(worker.spawns.map((spawn) => spawn.ticket.id), []);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("the Consumer selector filters which Tickets a Run picks", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  try {
+    await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [
+            ticket({ id: "52", labels: ["ready-for-agent"] }),
+            ticket({ id: "99", labels: ["other"] }),
+          ],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.deepEqual(worker.spawns.map((spawn) => spawn.ticket.id), ["52"]);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("an optional parent root narrows a Run to that parent's children", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  try {
+    await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [
+            ticket({ id: "11", parent: "8" }),
+            ticket({ id: "12", parent: "9" }),
+            ticket({ id: "8" }),
+          ],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+          parent: "8",
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 3,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.deepEqual(worker.spawns.map((spawn) => spawn.ticket.id), ["11"]);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("an optional ids root narrows a Run to that explicit list of Ticket ids", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  try {
+    await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [
+            ticket({ id: "52" }),
+            ticket({ id: "53" }),
+            ticket({ id: "57" }),
+          ],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+          ids: ["52", "57"],
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 3,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.deepEqual(worker.spawns.map((spawn) => spawn.ticket.id), ["52", "57"]);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("pick order is the adapter's stable ascending identifier order", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  try {
+    await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "57" }), ticket({ id: "52" })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.deepEqual(worker.spawns.map((spawn) => spawn.ticket.id), ["52", "57"]);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("the Frontier is recomputed after each Ticket so newly unblocked work is eligible in the same Run", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  try {
+    await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [
+            ticket({ id: "52" }),
+            ticket({ id: "53", blockedBy: ["52"] }),
+          ],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.deepEqual(worker.spawns.map((spawn) => spawn.ticket.id), ["52", "53"]);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("an empty Frontier stops the Run as a clean finish, not an error", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  try {
+    await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "99", labels: ["other"] })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 3,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(worker.spawns.length, 0);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a v0 Run starts one Worker at a time; each Ticket still gets its own Branch and Worktree", async () => {
+  const repo = await throwawayRepo();
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const worker = createWorkerAdapter({
+    async spawn() {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      inFlight -= 1;
+      return { exitCode: 0 };
+    },
+  });
+  try {
+    await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "52" }), ticket({ id: "57" })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(maxInFlight, 1);
+    await git(repo.cwd, ["rev-parse", "--verify", "refs/heads/readyrun/52"]);
+    await git(repo.cwd, ["rev-parse", "--verify", "refs/heads/readyrun/57"]);
+    const worktrees = await git(repo.cwd, ["worktree", "list", "--porcelain"]);
+    assert.match(worktrees, /readyrun\/52/);
+    assert.match(worktrees, /readyrun\/57/);
+    assert.equal(await git(repo.cwd, ["rev-parse", "--abbrev-ref", "HEAD"]), "main");
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("the Worker is given one Ticket, never a tree", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  try {
+    await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [
+            ticket({ id: "8" }),
+            ticket({ id: "11", parent: "8" }),
+            ticket({ id: "12", parent: "8" }),
+          ],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+          parent: "8",
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 3,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.deepEqual(worker.spawns.map((spawn) => spawn.ticket.id), ["11", "12"]);
+  } finally {
+    await repo.cleanup();
+  }
+});

--- a/test/run-one-ticket.test.ts
+++ b/test/run-one-ticket.test.ts
@@ -32,7 +32,11 @@ test("a Run with cap 1 against one unblocked Ticket starts exactly one Worker wi
   try {
     await run({
       config: defineConfig({
-        tracker: memoryTracker({ tickets: [ticket] }),
+        tracker: memoryTracker({
+          tickets: [ticket],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
         worker,
         model: "composer-2",
       }),
@@ -66,7 +70,11 @@ test("ReadyRun creates a Branch derived from the Ticket's identity; the Ticket b
   try {
     await run({
       config: defineConfig({
-        tracker: memoryTracker({ tickets: [ticket] }),
+        tracker: memoryTracker({
+          tickets: [ticket],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
         worker: recordingWorker({ exitCode: 0 }),
         model: "composer-2",
       }),
@@ -92,7 +100,11 @@ test("ReadyRun refuses to start a Worker on the default branch", async () => {
       () =>
         run({
           config: defineConfig({
-            tracker: memoryTracker({ tickets: [ticket] }),
+            tracker: memoryTracker({
+              tickets: [ticket],
+              ready: "unblocked",
+              labels: ["ready-for-agent"],
+            }),
             worker,
             model: "composer-2",
           }),
@@ -118,7 +130,11 @@ test("the Worker runs in a git Worktree on that Branch, not in the Consumer's pr
   try {
     await run({
       config: defineConfig({
-        tracker: memoryTracker({ tickets: [ticket] }),
+        tracker: memoryTracker({
+          tickets: [ticket],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
         worker,
         model: "composer-2",
       }),
@@ -139,7 +155,11 @@ test("the Worker runs in a git Worktree on that Branch, not in the Consumer's pr
 
 test("on Worker success, the Ticket leaves the Frontier via the Tracker Adapter default", async () => {
   const repo = await throwawayRepo();
-  const tracker = memoryTracker({ tickets: [ticket] });
+  const tracker = memoryTracker({
+    tickets: [ticket],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+  });
   try {
     await run({
       config: defineConfig({
@@ -161,7 +181,11 @@ test("on Worker success, the Ticket leaves the Frontier via the Tracker Adapter 
 
 test("a Consumer may override the Tracker Adapter's leave-Frontier default", async () => {
   const repo = await throwawayRepo();
-  const tracker = memoryTracker({ tickets: [ticket] });
+  const tracker = memoryTracker({
+    tickets: [ticket],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+  });
   const overridden: string[] = [];
   try {
     await run({
@@ -193,7 +217,11 @@ test("live status on stdout shows the current Ticket, cap used, and Branch", asy
   try {
     await run({
       config: defineConfig({
-        tracker: memoryTracker({ tickets: [ticket] }),
+        tracker: memoryTracker({
+          tickets: [ticket],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
         worker: recordingWorker({ exitCode: 0 }),
         model: "composer-2",
       }),
@@ -229,7 +257,11 @@ test("hitting the cap stops the Run without prompting", async () => {
   try {
     await run({
       config: defineConfig({
-        tracker: memoryTracker({ tickets: [ticket, second] }),
+        tracker: memoryTracker({
+          tickets: [ticket, second],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
         worker,
         model: "composer-2",
       }),

--- a/test/tracker-adapter-contract.ts
+++ b/test/tracker-adapter-contract.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { MemoryTrackerOptions } from "../src/testing/memory-tracker.ts";
+import type { Ticket } from "../src/ticket.ts";
+import type { TrackerAdapter } from "../src/tracker-adapter.ts";
+
+export type TrackerContractFactory = (
+  world: MemoryTrackerOptions,
+) => TrackerAdapter | Promise<TrackerAdapter>;
+
+export function ticket(
+  overrides: Partial<Ticket> & Pick<Ticket, "id">,
+): Ticket {
+  return {
+    title: `Ticket ${overrides.id}`,
+    body: "body",
+    url: `https://example.test/${overrides.id}`,
+    labels: ["ready-for-agent"],
+    blockedBy: [],
+    ...overrides,
+  };
+}
+
+export function trackerAdapterContract(
+  name: string,
+  create: TrackerContractFactory,
+): void {
+  test(`${name}: an unblocked Ticket that does not match the selector is not on the Frontier`, async () => {
+    const adapter = await create({
+      tickets: [
+        ticket({ id: "52", labels: ["ready-for-agent"] }),
+        ticket({ id: "99", labels: ["other"] }),
+      ],
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+    });
+
+    const frontier = await adapter.frontier();
+    assert.deepEqual(
+      frontier.map((ticket) => ticket.id),
+      ["52"],
+    );
+  });
+
+  test(`${name}: a blocked Ticket is never on the Frontier, even if it matches the selector`, async () => {
+    const adapter = await create({
+      tickets: [
+        ticket({ id: "52", labels: ["ready-for-agent"] }),
+        ticket({
+          id: "53",
+          labels: ["ready-for-agent"],
+          blockedBy: ["52"],
+        }),
+      ],
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+    });
+
+    const frontier = await adapter.frontier();
+    assert.deepEqual(
+      frontier.map((ticket) => ticket.id),
+      ["52"],
+    );
+  });
+
+  test(`${name}: an optional parent root narrows the Frontier to that parent's children`, async () => {
+    const adapter = await create({
+      tickets: [
+        ticket({ id: "11", parent: "8" }),
+        ticket({ id: "12", parent: "9" }),
+        ticket({ id: "8" }),
+      ],
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+      parent: "8",
+    });
+
+    const frontier = await adapter.frontier();
+    assert.deepEqual(
+      frontier.map((ticket) => ticket.id),
+      ["11"],
+    );
+  });
+
+  test(`${name}: an optional ids root narrows the Frontier to that explicit list of Ticket ids`, async () => {
+    const adapter = await create({
+      tickets: [
+        ticket({ id: "52" }),
+        ticket({ id: "53" }),
+        ticket({ id: "57" }),
+      ],
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+      ids: ["52", "57"],
+    });
+
+    const frontier = await adapter.frontier();
+    assert.deepEqual(
+      frontier.map((ticket) => ticket.id),
+      ["52", "57"],
+    );
+  });
+
+  test(`${name}: pick order is ascending identifier; there is no priority field on the Ticket`, async () => {
+    const adapter = await create({
+      tickets: [
+        ticket({ id: "57" }),
+        ticket({ id: "52" }),
+      ],
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+    });
+
+    const frontier = await adapter.frontier();
+    assert.deepEqual(
+      frontier.map((ticket) => ticket.id),
+      ["52", "57"],
+    );
+  });
+
+  test(`${name}: leaveFrontier makes the Ticket ineligible and unblocks Tickets that were waiting on it`, async () => {
+    const adapter = await create({
+      tickets: [
+        ticket({ id: "52" }),
+        ticket({ id: "53", blockedBy: ["52"] }),
+      ],
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+    });
+
+    const before = await adapter.frontier();
+    assert.deepEqual(
+      before.map((ticket) => ticket.id),
+      ["52"],
+    );
+
+    const finished = before[0];
+    assert.ok(finished);
+    await adapter.leaveFrontier(finished);
+
+    const after = await adapter.frontier();
+    assert.deepEqual(
+      after.map((ticket) => ticket.id),
+      ["53"],
+    );
+  });
+}


### PR DESCRIPTION
## Why

A Run that ignored blocking, labels, or pick order would start the wrong Ticket — including blocked work that merely matched the selector. After a Ticket finished, newly unblocked children would stay ineligible until a later invocation, so a map of dependent work could not be walked in one Run. An empty Frontier also has to be a normal ending, not an error, or "nothing is ready" looks like a crash.

## What

The in-memory Tracker Adapter answers the Frontier as `unblocked` plus labels, optionally narrowed by a parent or an explicit id list, in ascending identifier order. After each finish it is recomputed so dependents can run in the same invocation. A shared contract suite locks that behaviour; Run tests cover serial Workers, one Ticket never a tree, and a clean empty stop.

## How

Frontier evaluation lives in the Tracker Adapter. The Run still picks the first Ticket on that list, one Worker at a time.

Fixes #11

Made with [Cursor](https://cursor.com)