### PR TITLE
#12: End a Run on failure with a named stop and non-zero exit

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -1,11 +1,13 @@
 import { defineConfig, type ReadyRunConfig } from "./config.ts";
 import { createTicketWorktree } from "./git.ts";
 
+type RunStdout = { write(chunk: string): unknown };
+
 export type RunOptions = {
   config: ReadyRunConfig;
   cap?: number;
   cwd?: string;
-  stdout?: { write(chunk: string): unknown };
+  stdout?: RunStdout;
 };
 
 export class RunCapRequiredError extends Error {
@@ -15,7 +17,21 @@ export class RunCapRequiredError extends Error {
   }
 }
 
-export async function run(options: RunOptions): Promise<void> {
+type HardStopStage = "tracker" | "git" | "spawn" | "worker";
+
+function hardStop(
+  stdout: RunStdout,
+  stage: HardStopStage,
+  ticketId?: string,
+  detail?: string,
+): 1 {
+  const ticketPrefix = ticketId === undefined ? "" : `Ticket ${ticketId} `;
+  const suffix = detail === undefined ? "" : `: ${detail}`;
+  stdout.write(`Hard stop: ${ticketPrefix}failed at ${stage}${suffix}\n`);
+  return 1;
+}
+
+export async function run(options: RunOptions): Promise<number> {
   const config = defineConfig(options.config);
   const cap = options.cap ?? config.cap;
   if (cap === undefined) {
@@ -27,24 +43,49 @@ export async function run(options: RunOptions): Promise<void> {
   let started = 0;
 
   while (started < cap) {
-    const frontier = await config.tracker.frontier();
+    let frontier;
+    try {
+      frontier = await config.tracker.frontier();
+    } catch {
+      return hardStop(stdout, "tracker");
+    }
     const ticket = frontier[0];
     if (ticket === undefined) {
-      return;
+      return 0;
     }
 
     const branch = config.tracker.branchName(ticket);
-    const worktree = await createTicketWorktree(cwd, branch);
+    let worktree;
+    try {
+      worktree = await createTicketWorktree(cwd, branch);
+    } catch (error) {
+      return hardStop(
+        stdout,
+        "git",
+        ticket.id,
+        error instanceof Error ? error.message : undefined,
+      );
+    }
     started += 1;
     stdout.write(`Ticket ${ticket.id}  ${started}/${cap}  ${branch}\n`);
-    const result = await config.worker.spawn({ ticket, cwd: worktree });
-    if (result.exitCode !== 0) {
-      return;
+    let result;
+    try {
+      result = await config.worker.spawn({ ticket, cwd: worktree });
+    } catch {
+      return hardStop(stdout, "spawn", ticket.id);
     }
-    if (config.leaveFrontier) {
-      await config.leaveFrontier(ticket);
-    } else {
-      await config.tracker.leaveFrontier(ticket);
+    if (result.exitCode !== 0) {
+      return hardStop(stdout, "worker", ticket.id);
+    }
+    try {
+      if (config.leaveFrontier) {
+        await config.leaveFrontier(ticket);
+      } else {
+        await config.tracker.leaveFrontier(ticket);
+      }
+    } catch {
+      return hardStop(stdout, "tracker", ticket.id);
     }
   }
+  return 0;
 }

--- a/test/run-hard-stop.test.ts
+++ b/test/run-hard-stop.test.ts
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { test } from "node:test";
+import { promisify } from "node:util";
+import { defineConfig, run } from "../src/mod.ts";
+import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
+import { createTrackerAdapter } from "../src/tracker-adapter.ts";
+import { createWorkerAdapter } from "../src/worker-adapter.ts";
+import { ticket } from "./tracker-adapter-contract.ts";
+import { throwawayRepo } from "./throwaway-repo.ts";
+
+const exec = promisify(execFile);
+const silent = { write(_chunk?: string) { return true; } };
+
+test("an empty Frontier is a clean finish distinguished by exit code 0", async () => {
+  const repo = await throwawayRepo();
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "99", labels: ["other"] })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cap: 3,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(exitCode, 0);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("hitting the cap is a clean finish distinguished by exit code 0", async () => {
+  const repo = await throwawayRepo();
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "52" }), ticket({ id: "57" })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(exitCode, 0);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a Worker exiting non-zero hard-stops the Run without skip or retry", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 1 });
+  const tracker = memoryTracker({
+    tickets: [ticket({ id: "52" }), ticket({ id: "57" })],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+  });
+  const chunks: string[] = [];
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker,
+        worker,
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(worker.spawns.map((spawn) => spawn.ticket.id), ["52"]);
+    assert.deepEqual(
+      (await tracker.frontier()).map((item) => item.id),
+      ["52", "57"],
+    );
+    const output = chunks.join("");
+    assert.match(output, /Hard stop: Ticket 52 failed at worker/);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a Tracker API or auth failure hard-stops the Run", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  const chunks: string[] = [];
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: createTrackerAdapter({
+          frontier() {
+            return Promise.reject(new Error("401 Unauthorized"));
+          },
+          branchName(ticket) {
+            return `readyrun/${ticket.id}`;
+          },
+          leaveFrontier() {
+            return Promise.resolve();
+          },
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.equal(worker.spawns.length, 0);
+    assert.match(chunks.join(""), /Hard stop: failed at tracker/);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a git failure creating the Branch or Worktree hard-stops the Run; a Worker never runs in the wrong place", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  await exec("git", ["-C", repo.cwd, "branch", "readyrun/52"]);
+  const chunks: string[] = [];
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "52" }), ticket({ id: "57" })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.equal(worker.spawns.length, 0);
+    assert.match(chunks.join(""), /Hard stop: Ticket 52 failed at git/);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a missing or unauthenticated Worker at spawn hard-stops the Run", async () => {
+  const repo = await throwawayRepo();
+  const attempted: string[] = [];
+  const worker = createWorkerAdapter({
+    spawn(request) {
+      attempted.push(request.ticket.id);
+      return Promise.reject(new Error("Worker is not logged in"));
+    },
+  });
+  const chunks: string[] = [];
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "52" }), ticket({ id: "57" })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(attempted, ["52"]);
+    assert.match(chunks.join(""), /Hard stop: Ticket 52 failed at spawn/);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a Tracker failure finishing a Ticket hard-stops the Run and names that Ticket", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  const inner = memoryTracker({
+    tickets: [ticket({ id: "52" }), ticket({ id: "57" })],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+  });
+  const chunks: string[] = [];
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: createTrackerAdapter({
+          frontier: () => inner.frontier(),
+          branchName: (ticket) => inner.branchName(ticket),
+          leaveFrontier() {
+            return Promise.reject(new Error("GitHub API 500"));
+          },
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(worker.spawns.map((spawn) => spawn.ticket.id), ["52"]);
+    assert.match(chunks.join(""), /Hard stop: Ticket 52 failed at tracker/);
+  } finally {
+    await repo.cleanup();
+  }
+});

--- a/test/run-one-ticket.test.ts
+++ b/test/run-one-ticket.test.ts
@@ -95,30 +95,31 @@ test("ReadyRun creates a Branch derived from the Ticket's identity; the Ticket b
 test("ReadyRun refuses to start a Worker on the default branch", async () => {
   const repo = await throwawayRepo({ defaultBranch: "readyrun/52" });
   const worker = recordingWorker({ exitCode: 0 });
+  const chunks: string[] = [];
   try {
-    await assert.rejects(
-      () =>
-        run({
-          config: defineConfig({
-            tracker: memoryTracker({
-              tickets: [ticket],
-              ready: "unblocked",
-              labels: ["ready-for-agent"],
-            }),
-            worker,
-            model: "composer-2",
-          }),
-          cap: 1,
-          cwd: repo.cwd,
-          stdout: silent,
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
         }),
-      (error: unknown) => {
-        assert.ok(error instanceof Error);
-        assert.match(error.message, /default branch/);
-        return true;
+        worker,
+        model: "composer-2",
+      }),
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
       },
-    );
+    });
+    assert.equal(exitCode, 1);
     assert.equal(worker.spawns.length, 0);
+    assert.match(chunks.join(""), /Hard stop: Ticket 52 failed at git/);
+    assert.match(chunks.join(""), /default branch/);
   } finally {
     await repo.cleanup();
   }


### PR DESCRIPTION
## Why

A loop that skips a failed Ticket hides the break behind later work, and retrying a flapping Tracker eats the cap. An unattended Run also has to tell "nothing left to do" from "the Worker died", or a script cannot drive it.

## What

Tracker API or auth failure, git failure creating the Branch or Worktree, a missing or unauthenticated Worker at spawn, and a non-zero Worker exit all end the Run with exit code 1. The stop names the Ticket and the stage. Empty Frontier and a reached cap stay exit 0. There is no skip and no retry.

## How

`run()` returns that exit code. Tests assemble `defineConfig` with the in-memory Tracker and a scripted Worker, then call the same entry point; git failures use a throwaway repository.

Fixes #12


Made with [Cursor](https://cursor.com)