### PR TITLE
#14: Fail Doctor on Frontier lies and report the next Ticket

### DIFF
--- a/src/adapters/custom.ts
+++ b/src/adapters/custom.ts
@@ -18,5 +18,5 @@ export type CustomWorkerAdapter = WorkerAdapter & {
 
 export function custom(options: CustomWorkerOptions): CustomWorkerAdapter {
   assertKnownKeys(options, knownCustomKeys);
-  return Object.assign(createWorkerAdapter(), { options });
+  return Object.assign(createWorkerAdapter({ bin: options.bin }), { options });
 }

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -22,5 +22,17 @@ export type GitHubTrackerOptions = {
 
 export function github(options: GitHubTrackerOptions): TrackerAdapter {
   assertKnownKeys(options, knownGitHubKeys);
-  return Object.assign(createTrackerAdapter(), { options });
+  return Object.assign(
+    createTrackerAdapter({
+      inspect() {
+        return Promise.resolve({
+          existingLabels: options.labels,
+          selectorLabels: options.labels,
+          repository: options.repo,
+          canExpressBlocking: true,
+        });
+      },
+    }),
+    { options },
+  );
 }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,0 +1,105 @@
+import { existsSync } from "node:fs";
+import { delimiter, isAbsolute, join } from "node:path";
+import { defineConfig, type ReadyRunConfig } from "./config.ts";
+import { originRepository, normalizeRepository } from "./git.ts";
+import type { Ticket } from "./ticket.ts";
+
+type DoctorStdout = { write(chunk: string): unknown };
+
+export type DoctorOptions = {
+  config: ReadyRunConfig;
+  cwd?: string;
+  stdout?: DoctorStdout;
+};
+
+async function check(
+  config: ReadyRunConfig,
+  cwd: string,
+): Promise<string[]> {
+  const failures: string[] = [];
+  if (typeof config.model !== "string" || config.model.length === 0) {
+    failures.push("missing model default");
+  }
+  const inspect = await config.tracker.inspect();
+  for (const label of inspect.selectorLabels) {
+    if (!inspect.existingLabels.includes(label)) {
+      failures.push(`label "${label}" does not exist on the Tracker`);
+    }
+  }
+  if (inspect.repository !== undefined) {
+    const remote = await originRepository(cwd);
+    if (remote !== normalizeRepository(inspect.repository)) {
+      failures.push(
+        `configured repository ${inspect.repository} is not the git remote (${remote ?? "none"})`,
+      );
+    }
+  }
+  if (!inspect.canExpressBlocking) {
+    failures.push(
+      "Tracker cannot express blocking; unblocked ordering is a lie",
+    );
+  }
+  if (config.worker.bin !== undefined && !workerBinaryExists(config.worker.bin)) {
+    failures.push(`Worker binary "${config.worker.bin}" is missing`);
+  }
+  return failures;
+}
+
+function workerBinaryExists(bin: string): boolean {
+  if (isAbsolute(bin) || bin.includes("/") || bin.includes("\\")) {
+    return existsSync(bin);
+  }
+  const path = process.env.PATH ?? "";
+  return path.split(delimiter).some((dir) => existsSync(join(dir, bin)));
+}
+
+export function warnUnusedModelsByLabel(
+  stdout: DoctorStdout,
+  modelsByLabel: Record<string, string> | undefined,
+  frontier: Ticket[],
+): void {
+  if (modelsByLabel === undefined) {
+    return;
+  }
+  const present = new Set(frontier.flatMap((ticket) => ticket.labels));
+  for (const label of Object.keys(modelsByLabel)) {
+    if (!present.has(label)) {
+      stdout.write(
+        `Warning: modelsByLabel key "${label}" matches no Tickets on the Frontier\n`,
+      );
+    }
+  }
+}
+
+export async function doctorCheck(
+  config: ReadyRunConfig,
+  cwd: string,
+  stdout: DoctorStdout,
+): Promise<0 | 1> {
+  const failures = await check(config, cwd);
+  if (failures.length === 0) {
+    return 0;
+  }
+  for (const failure of failures) {
+    stdout.write(`Doctor: ${failure}\n`);
+  }
+  return 1;
+}
+
+export async function doctor(options: DoctorOptions): Promise<number> {
+  const config = defineConfig(options.config);
+  const cwd = options.cwd ?? process.cwd();
+  const stdout = options.stdout ?? process.stdout;
+  if (await doctorCheck(config, cwd, stdout) === 1) {
+    return 1;
+  }
+  const frontier = await config.tracker.frontier();
+  warnUnusedModelsByLabel(stdout, config.modelsByLabel, frontier);
+  const next = frontier[0];
+  if (next === undefined) {
+    stdout.write("Frontier is empty\n");
+  } else {
+    stdout.write(`Next Ticket: ${next.id}\n`);
+  }
+  return 0;
+}

--- a/src/git.ts
+++ b/src/git.ts
@@ -44,6 +44,28 @@ async function defaultBranch(cwd: string): Promise<string> {
   }
 }
 
+export async function originRepository(cwd: string): Promise<string | undefined> {
+  try {
+    return parseOwnerRepo(await git(cwd, ["remote", "get-url", "origin"]));
+  } catch {
+    return undefined;
+  }
+}
+
+export function normalizeRepository(value: string): string {
+  return value.trim().replace(/\/+$/, "").replace(/\.git$/i, "").toLowerCase();
+}
+
+function parseOwnerRepo(url: string): string | undefined {
+  const trimmed = normalizeRepository(url);
+  const ssh = trimmed.match(/^git@[^:]+:(.+\/.+)$/);
+  if (ssh?.[1] !== undefined) {
+    return ssh[1];
+  }
+  const path = trimmed.match(/[:/]([^/]+\/[^/]+)$/);
+  return path?.[1];
+}
+
 export async function createTicketWorktree(
   cwd: string,
   branch: string,

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,10 +1,12 @@
 export { defineConfig } from "./config.ts";
 export type { ReadyRunConfig } from "./config.ts";
+export { doctor } from "./doctor.ts";
+export type { DoctorOptions } from "./doctor.ts";
 export { run, RunCapRequiredError } from "./run.ts";
 export type { RunOptions } from "./run.ts";
 export { DefaultBranchError } from "./git.ts";
 export type { Ticket } from "./ticket.ts";
-export type { TrackerAdapter } from "./tracker-adapter.ts";
+export type { TrackerAdapter, TrackerInspect } from "./tracker-adapter.ts";
 export type { Permissions, SpawnRequest, WorkerAdapter } from "./worker-adapter.ts";
 export { UnknownConfigKeyError } from "./unknown-keys.ts";
 export { github } from "./adapters/github.ts";

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { defineConfig, type ReadyRunConfig } from "./config.ts";
+import { doctorCheck, warnUnusedModelsByLabel } from "./doctor.ts";
 import { createTicketWorktree } from "./git.ts";
 import { composeWorkerPrompt } from "./prompt.ts";
 import type { Ticket } from "./ticket.ts";
@@ -21,24 +22,6 @@ export class RunCapRequiredError extends Error {
   constructor() {
     super("A Run cannot start without a cap");
     this.name = "RunCapRequiredError";
-  }
-}
-
-function warnUnusedModelsByLabel(
-  stdout: RunStdout,
-  modelsByLabel: Record<string, string> | undefined,
-  frontier: Ticket[],
-): void {
-  if (modelsByLabel === undefined) {
-    return;
-  }
-  const present = new Set(frontier.flatMap((ticket) => ticket.labels));
-  for (const label of Object.keys(modelsByLabel)) {
-    if (!present.has(label)) {
-      stdout.write(
-        `Warning: modelsByLabel key "${label}" matches no Tickets on the Frontier\n`,
-      );
-    }
   }
 }
 
@@ -76,6 +59,9 @@ export async function run(options: RunOptions): Promise<number> {
 
   const cwd = options.cwd ?? process.cwd();
   const stdout = options.stdout ?? process.stdout;
+  if (await doctorCheck(config, cwd, stdout) === 1) {
+    return 1;
+  }
   const context = config.contextFile === undefined
     ? undefined
     : await readFile(join(cwd, config.contextFile), "utf8");

--- a/src/testing/memory-tracker.ts
+++ b/src/testing/memory-tracker.ts
@@ -7,6 +7,8 @@ export type MemoryTrackerOptions = {
   labels: string[];
   parent?: string;
   ids?: string[];
+  existingLabels?: string[];
+  canExpressBlocking?: boolean;
 };
 
 export function memoryTracker(options: MemoryTrackerOptions): TrackerAdapter {
@@ -47,6 +49,19 @@ export function memoryTracker(options: MemoryTrackerOptions): TrackerAdapter {
     },
     promptCopy(ticket) {
       return `This Ticket is ${ticket.id} on the in-memory Tracker.\nTitle: ${ticket.title}\n\n${ticket.body}\n\n${ticket.url}`;
+    },
+    inspect() {
+      const existingLabels = options.existingLabels ?? [
+        ...new Set([
+          ...options.labels,
+          ...options.tickets.flatMap((ticket) => ticket.labels),
+        ]),
+      ];
+      return Promise.resolve({
+        existingLabels,
+        selectorLabels: options.labels,
+        canExpressBlocking: options.canExpressBlocking ?? true,
+      });
     },
   });
 }

--- a/src/tracker-adapter.ts
+++ b/src/tracker-adapter.ts
@@ -2,17 +2,25 @@ import type { Ticket } from "./ticket.ts";
 
 const brand = Symbol("TrackerAdapter");
 
+export type TrackerInspect = {
+  readonly existingLabels: readonly string[];
+  readonly selectorLabels: readonly string[];
+  readonly repository?: string;
+  readonly canExpressBlocking: boolean;
+};
+
 export type TrackerAdapter = {
   readonly [brand]: true;
   frontier(): Promise<Ticket[]>;
   branchName(ticket: Ticket): string;
   leaveFrontier(ticket: Ticket): Promise<void>;
   promptCopy(ticket: Ticket): string;
+  inspect(): Promise<TrackerInspect>;
 };
 
 const defaults: Pick<
   TrackerAdapter,
-  "frontier" | "branchName" | "leaveFrontier" | "promptCopy"
+  "frontier" | "branchName" | "leaveFrontier" | "promptCopy" | "inspect"
 > = {
   frontier() {
     return Promise.resolve([]);
@@ -26,11 +34,21 @@ const defaults: Pick<
   promptCopy(ticket) {
     return `Ticket ${ticket.id}: ${ticket.title}\n\n${ticket.body}\n\n${ticket.url}`;
   },
+  inspect() {
+    return Promise.resolve({
+      existingLabels: [],
+      selectorLabels: [],
+      canExpressBlocking: true,
+    });
+  },
 };
 
 export function createTrackerAdapter(
   methods: Partial<
-    Pick<TrackerAdapter, "frontier" | "branchName" | "leaveFrontier" | "promptCopy">
+    Pick<
+      TrackerAdapter,
+      "frontier" | "branchName" | "leaveFrontier" | "promptCopy" | "inspect"
+    >
   > = {},
 ): TrackerAdapter {
   return { [brand]: true, ...defaults, ...methods };

--- a/src/worker-adapter.ts
+++ b/src/worker-adapter.ts
@@ -14,15 +14,18 @@ export type SpawnRequest = {
 
 export type WorkerAdapter = {
   readonly [brand]: true;
+  readonly bin?: string;
   spawn(request: SpawnRequest): Promise<{ exitCode: number }>;
 };
 
 export function createWorkerAdapter(
-  methods: Pick<WorkerAdapter, "spawn"> = {
+  methods: Partial<Pick<WorkerAdapter, "spawn" | "bin">> = {},
+): WorkerAdapter {
+  return {
+    [brand]: true,
     spawn() {
       return Promise.reject(new Error("Worker Adapter cannot spawn"));
     },
-  },
-): WorkerAdapter {
-  return { [brand]: true, ...methods };
+    ...methods,
+  };
 }

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -1,0 +1,418 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { test } from "node:test";
+import { promisify } from "node:util";
+import { defineConfig, custom, doctor, github, run, UnknownConfigKeyError } from "../src/mod.ts";
+import type { ReadyRunConfig } from "../src/mod.ts";
+import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
+import { createTrackerAdapter } from "../src/tracker-adapter.ts";
+import { ticket } from "./tracker-adapter-contract.ts";
+import { throwawayRepo } from "./throwaway-repo.ts";
+
+const exec = promisify(execFile);
+const silent = { write(_chunk?: string) { return true; } };
+
+test("a label named in the selector that does not exist on the Tracker fails Doctor and a Run will not start", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  const chunks: string[] = [];
+  const config = defineConfig({
+    tracker: memoryTracker({
+      tickets: [ticket({ id: "52" })],
+      ready: "unblocked",
+      labels: ["does-not-exist"],
+      existingLabels: ["ready-for-agent"],
+    }),
+    worker,
+    model: "composer-2",
+  });
+  try {
+    const doctorExit = await doctor({
+      config,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(doctorExit, 1);
+    assert.match(
+      chunks.join(""),
+      /Doctor: label "does-not-exist" does not exist on the Tracker/,
+    );
+
+    const runExit = await run({
+      config,
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+    assert.equal(runExit, 1);
+    assert.equal(worker.spawns.length, 0);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("Doctor reports the Ticket that would be picked next, and that is the Ticket a Run actually starts", async () => {
+  const repo = await throwawayRepo();
+  const tracker = memoryTracker({
+    tickets: [ticket({ id: "57" }), ticket({ id: "52" })],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+  });
+  const worker = recordingWorker({ exitCode: 0 });
+  const chunks: string[] = [];
+  const config = defineConfig({
+    tracker,
+    worker,
+    model: "composer-2",
+  });
+  try {
+    const doctorExit = await doctor({
+      config,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+
+    assert.equal(doctorExit, 0);
+    assert.match(chunks.join(""), /Next Ticket: 52/);
+
+    await run({
+      config,
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(worker.spawns[0]?.ticket.id, "52");
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a configured repository that is not the git remote fails Doctor and a Run will not start", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  await exec("git", [
+    "-C",
+    repo.cwd,
+    "remote",
+    "add",
+    "origin",
+    "git@github.com:other/place.git",
+  ]);
+  const chunks: string[] = [];
+  const config = defineConfig({
+    tracker: github({
+      repo: "acme/widgets",
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+    }),
+    worker,
+    model: "composer-2",
+  });
+  try {
+    const doctorExit = await doctor({
+      config,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(doctorExit, 1);
+    assert.match(
+      chunks.join(""),
+      /Doctor: configured repository acme\/widgets is not the git remote \(other\/place\)/,
+    );
+
+    const runExit = await run({
+      config,
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+    assert.equal(runExit, 1);
+    assert.equal(worker.spawns.length, 0);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("claiming unblocked when the Tracker cannot express blocking fails Doctor and a Run will not start", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  const chunks: string[] = [];
+  const config = defineConfig({
+    tracker: memoryTracker({
+      tickets: [ticket({ id: "52" })],
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+      canExpressBlocking: false,
+    }),
+    worker,
+    model: "composer-2",
+  });
+  try {
+    const doctorExit = await doctor({
+      config,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(doctorExit, 1);
+    assert.match(
+      chunks.join(""),
+      /Doctor: Tracker cannot express blocking; unblocked ordering is a lie/,
+    );
+
+    const runExit = await run({
+      config,
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+    assert.equal(runExit, 1);
+    assert.equal(worker.spawns.length, 0);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a missing Worker binary fails Doctor and a Run will not start", async () => {
+  const repo = await throwawayRepo();
+  const worker = custom({
+    bin: "/no/such/readyrun-worker",
+    unattendedFlag: "--dangerously-skip-permissions",
+  });
+  const chunks: string[] = [];
+  const config = defineConfig({
+    tracker: memoryTracker({
+      tickets: [ticket({ id: "52" })],
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+    }),
+    worker,
+    model: "composer-2",
+  });
+  try {
+    const doctorExit = await doctor({
+      config,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(doctorExit, 1);
+    assert.match(
+      chunks.join(""),
+      /Doctor: Worker binary "\/no\/such\/readyrun-worker" is missing/,
+    );
+
+    const runChunks: string[] = [];
+    const runExit = await run({
+      config,
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          runChunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(runExit, 1);
+    assert.match(
+      runChunks.join(""),
+      /Doctor: Worker binary "\/no\/such\/readyrun-worker" is missing/,
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a missing model default fails Doctor and a Run will not start", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  const chunks: string[] = [];
+  const config = {
+    tracker: memoryTracker({
+      tickets: [ticket({ id: "52" })],
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+    }),
+    worker,
+  } as unknown as ReadyRunConfig;
+  try {
+    const doctorExit = await doctor({
+      config,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(doctorExit, 1);
+    assert.match(chunks.join(""), /Doctor: missing model default/);
+
+    const runExit = await run({
+      config,
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+    assert.equal(runExit, 1);
+    assert.equal(worker.spawns.length, 0);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a by-label model map that matches no Tickets is a warning, not a failure", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  const chunks: string[] = [];
+  const config = defineConfig({
+    tracker: memoryTracker({
+      tickets: [ticket({ id: "52" })],
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+    }),
+    worker,
+    model: "composer-2",
+    modelsByLabel: { review: "haiku" },
+  });
+  try {
+    const doctorExit = await doctor({
+      config,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(doctorExit, 0);
+    assert.match(
+      chunks.join(""),
+      /Warning: modelsByLabel key "review" matches no Tickets on the Frontier/,
+    );
+    assert.match(chunks.join(""), /Next Ticket: 52/);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("Doctor reports an empty Frontier without failing", async () => {
+  const repo = await throwawayRepo();
+  const chunks: string[] = [];
+  try {
+    const doctorExit = await doctor({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "99", labels: ["other"] })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(doctorExit, 0);
+    assert.match(chunks.join(""), /Frontier is empty/);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("unknown keys fail Doctor", async () => {
+  const config = {
+    tracker: memoryTracker({
+      tickets: [ticket({ id: "52" })],
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+    }),
+    worker: recordingWorker({ exitCode: 0 }),
+    model: "composer-2",
+    unknownKnob: true,
+  };
+
+  await assert.rejects(
+    () => doctor({ config }),
+    (error: unknown) => {
+      assert.ok(error instanceof UnknownConfigKeyError);
+      assert.deepEqual([...error.keys], ["unknownKnob"]);
+      return true;
+    },
+  );
+});
+
+test("the check runs once at Run start, not on every iteration", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  const inner = memoryTracker({
+    tickets: [ticket({ id: "52" }), ticket({ id: "57" })],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+  });
+  let inspects = 0;
+  const tracker = createTrackerAdapter({
+    frontier: () => inner.frontier(),
+    branchName: (ticket) => inner.branchName(ticket),
+    leaveFrontier: (ticket) => inner.leaveFrontier(ticket),
+    promptCopy: (ticket) => inner.promptCopy(ticket),
+    inspect() {
+      inspects += 1;
+      if (inspects > 1) {
+        return Promise.reject(new Error("Doctor check ran more than once"));
+      }
+      return inner.inspect();
+    },
+  });
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker,
+        worker,
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+    assert.equal(exitCode, 0);
+    assert.deepEqual(
+      worker.spawns.map((spawn) => spawn.ticket.id),
+      ["52", "57"],
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});


### PR DESCRIPTION
## Why

A stale or invented Frontier burns the cap: a missing label, the wrong git remote, or a Worker binary that is not there only shows up after a Ticket is claimed. Warn-and-continue was rejected for that reason. Doctor also has to name the Ticket that would run next, or an unattended Run cannot be trusted.

## What

Doctor and Run start share one check. Unknown keys, a missing selector label, config repo ≠ git remote, `unblocked` when the Tracker cannot express blocking, a missing Worker binary, and a missing model default all refuse to start. Unused by-label routing warns. Doctor prints the next Ticket.

## How

Tests assemble `defineConfig` with the in-memory Tracker and recording Worker, then call `doctor()` and `run()` — the same entries the CLI will use. Git remotes are real throwaway repositories.

## Workarounds

GitHub `inspect()` still echoes configured labels rather than listing the repository's labels; talking to GitHub is #17. `cursor()` / `claude()` do not set `bin` yet; that is #15.

Fixes #14


Made with [Cursor](https://cursor.com)