### PR TITLE
#16: Translate run and doctor flags into the programmatic entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Walk a tracker Frontier and run one coding Worker per Ticket.",
   "license": "MIT",
   "type": "module",
+  "bin": {
+    "readyrun": "./src/cli.ts"
+  },
   "exports": {
     ".": "./src/mod.ts"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { doctor as doctorEntry, type DoctorOptions } from "./doctor.ts";
+import { run as runEntry, RunCapRequiredError, type RunOptions } from "./run.ts";
+import type { ReadyRunConfig } from "./config.ts";
+import type { Permissions } from "./worker-adapter.ts";
+
+type Writer = { write(chunk: string): unknown };
+
+const usage = `Usage: readyrun <command>
+
+Commands:
+  run --max <n> [--model <id>] [--permissions ask|unattended]
+  doctor
+
+A Run cannot start without a cap.
+`;
+
+const configNames = [
+  "readyrun.config.ts",
+  "readyrun.config.js",
+  "readyrun.config.mjs",
+] as const;
+
+export class ConfigNotFoundError extends Error {
+  constructor() {
+    super(
+      "No readyrun.config.ts, readyrun.config.js, or readyrun.config.mjs at the Consumer root",
+    );
+    this.name = "ConfigNotFoundError";
+  }
+}
+
+export class AmbiguousConfigError extends Error {
+  constructor(names: readonly string[]) {
+    super(`Multiple config files at the Consumer root: ${names.join(", ")}`);
+    this.name = "AmbiguousConfigError";
+  }
+}
+
+export class ConfigExportError extends Error {
+  constructor(name: string) {
+    super(`${name} must default-export defineConfig(...)`);
+    this.name = "ConfigExportError";
+  }
+}
+
+export async function loadConfig(cwd: string): Promise<ReadyRunConfig> {
+  const found = configNames.filter((name) => existsSync(join(cwd, name)));
+  if (found.length === 0) {
+    throw new ConfigNotFoundError();
+  }
+  if (found.length > 1) {
+    throw new AmbiguousConfigError(found);
+  }
+  const name = found[0];
+  if (name === undefined) {
+    throw new ConfigNotFoundError();
+  }
+  const mod: { default?: ReadyRunConfig } = await import(
+    pathToFileURL(join(cwd, name)).href
+  );
+  if (mod.default === undefined) {
+    throw new ConfigExportError(name);
+  }
+  return mod.default;
+}
+
+export type CliOptions = {
+  argv: string[];
+  cwd?: string;
+  stdout?: Writer;
+  loadConfig?: (cwd: string) => Promise<ReadyRunConfig>;
+  run?: (options: RunOptions) => Promise<number>;
+  doctor?: (options: DoctorOptions) => Promise<number>;
+};
+
+type RunFlags = {
+  cap?: number;
+  permissions?: Permissions;
+  model?: string;
+};
+
+function parseRunFlags(args: string[]):
+  | ({ ok: true } & RunFlags)
+  | { ok: false; message: string } {
+  let cap: number | undefined;
+  let permissions: Permissions | undefined;
+  let model: string | undefined;
+  let sawMax = false;
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--max") {
+      sawMax = true;
+      cap = Number(args[i + 1]);
+      i += 1;
+    } else if (arg === "--permissions") {
+      const value = args[i + 1];
+      if (value !== "ask" && value !== "unattended") {
+        return { ok: false, message: "Permissions must be ask or unattended" };
+      }
+      permissions = value;
+      i += 1;
+    } else if (arg === "--model") {
+      model = args[i + 1];
+      i += 1;
+    }
+  }
+  if (sawMax && (cap === undefined || !Number.isInteger(cap) || cap < 1)) {
+    return { ok: false, message: "A Run cannot start without a cap" };
+  }
+  return { ok: true, cap, permissions, model };
+}
+
+export async function cli(options: CliOptions): Promise<number> {
+  const stdout = options.stdout ?? process.stdout;
+  const command = options.argv[0];
+  if (command !== "run" && command !== "doctor") {
+    stdout.write(usage);
+    return 1;
+  }
+  let runFlags: RunFlags | undefined;
+  if (command === "run") {
+    const flags = parseRunFlags(options.argv.slice(1));
+    if (!flags.ok) {
+      stdout.write(`${flags.message}\n`);
+      return 1;
+    }
+    runFlags = flags;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  let config: ReadyRunConfig;
+  try {
+    config = await (options.loadConfig ?? loadConfig)(cwd);
+  } catch (error) {
+    stdout.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+  if (runFlags !== undefined) {
+    const invoke = options.run ?? runEntry;
+    try {
+      return await invoke({
+        config,
+        cap: runFlags.cap,
+        cwd,
+        stdout,
+        permissions: runFlags.permissions,
+        model: runFlags.model,
+      });
+    } catch (error) {
+      if (error instanceof RunCapRequiredError) {
+        stdout.write(`${error.message}\n`);
+        return 1;
+      }
+      throw error;
+    }
+  }
+  const invoke = options.doctor ?? doctorEntry;
+  return invoke({ config, cwd, stdout });
+}
+
+function isCliEntry(): boolean {
+  const argv1 = process.argv[1];
+  if (argv1 === undefined) {
+    return false;
+  }
+  return import.meta.url === pathToFileURL(resolve(argv1)).href;
+}
+
+if (isCliEntry()) {
+  process.exitCode = await cli({ argv: process.argv.slice(2) });
+}
+

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,283 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import { cli, loadConfig } from "../src/cli.ts";
+import { defineConfig, type DoctorOptions, type RunOptions } from "../src/mod.ts";
+import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
+
+const silent = { write(_chunk?: string) { return true; } };
+
+const config = defineConfig({
+  tracker: memoryTracker({
+    tickets: [],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+  }),
+  worker: recordingWorker(),
+  model: "composer-2",
+});
+
+const tmpRoot = join(fileURLToPath(new URL(".", import.meta.url)), ".tmp");
+const packageHref = pathToFileURL(
+  join(fileURLToPath(new URL(".", import.meta.url)), "../src/mod.ts"),
+).href;
+
+function consumerConfigSource(): string {
+  return `import { defineConfig, github, cursor } from ${JSON.stringify(packageHref)};
+
+export default defineConfig({
+  tracker: github({
+    repo: "acme/widgets",
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+  }),
+  worker: cursor(),
+  model: "composer-2",
+});
+`;
+}
+
+async function withConsumerRoot(
+  setup: (cwd: string) => Promise<void>,
+  fn: (cwd: string) => Promise<void>,
+): Promise<void> {
+  await mkdir(tmpRoot, { recursive: true });
+  const cwd = await mkdtemp(join(tmpRoot, "consumer-"));
+  try {
+    await setup(cwd);
+    await fn(cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+test("bare readyrun prints usage rather than opening a menu", async () => {
+  const chunks: string[] = [];
+  const exitCode = await cli({
+    argv: [],
+    stdout: {
+      write(chunk: string) {
+        chunks.push(chunk);
+        return true;
+      },
+    },
+  });
+  const output = chunks.join("");
+  assert.match(output, /Usage: readyrun/);
+  assert.match(output, /run --max/);
+  assert.match(output, /doctor/);
+  assert.doesNotMatch(output, /menu|wizard|select/i);
+  assert.equal(exitCode, 1);
+});
+
+test("readyrun run --max N hands the same options object the programmatic entry takes", async () => {
+  const received: RunOptions[] = [];
+  const exitCode = await cli({
+    argv: ["run", "--max", "5"],
+    cwd: "/consumer",
+    stdout: silent,
+    loadConfig: async () => config,
+    run: async (options) => {
+      received.push(options);
+      return 0;
+    },
+  });
+  assert.equal(exitCode, 0);
+  assert.equal(received.length, 1);
+  assert.equal(received[0]?.cap, 5);
+  assert.equal(received[0]?.config, config);
+  assert.equal(received[0]?.cwd, "/consumer");
+  assert.equal(received[0]?.permissions, undefined);
+});
+
+test("a Run without a cap is refused at the CLI", async () => {
+  const chunks: string[] = [];
+  const exitCode = await cli({
+    argv: ["run"],
+    stdout: {
+      write(chunk: string) {
+        chunks.push(chunk);
+        return true;
+      },
+    },
+    loadConfig: async () => config,
+  });
+  assert.equal(exitCode, 1);
+  assert.match(chunks.join(""), /A Run cannot start without a cap/);
+});
+
+test("readyrun run uses a cap supplied in config when --max is omitted", async () => {
+  const received: RunOptions[] = [];
+  const withCap = defineConfig({ ...config, cap: 3 });
+  const exitCode = await cli({
+    argv: ["run"],
+    stdout: silent,
+    loadConfig: async () => withCap,
+    run: async (options) => {
+      received.push(options);
+      return 0;
+    },
+  });
+  assert.equal(exitCode, 0);
+  assert.equal(received[0]?.cap, undefined);
+  assert.equal(received[0]?.config.cap, 3);
+});
+
+test("permissions default to ask unless the operator passes unattended", async () => {
+  const received: RunOptions[] = [];
+  await cli({
+    argv: ["run", "--max", "1"],
+    stdout: silent,
+    loadConfig: async () => config,
+    run: async (options) => {
+      received.push(options);
+      return 0;
+    },
+  });
+  assert.equal(received[0]?.permissions, undefined);
+  await cli({
+    argv: ["run", "--max", "1", "--permissions", "unattended"],
+    stdout: silent,
+    loadConfig: async () => config,
+    run: async (options) => {
+      received.push(options);
+      return 0;
+    },
+  });
+  assert.equal(received[1]?.permissions, "unattended");
+});
+
+test("--model overrides the config default for this Run", async () => {
+  const received: RunOptions[] = [];
+  await cli({
+    argv: ["run", "--max", "1", "--model", "opus"],
+    stdout: silent,
+    loadConfig: async () => config,
+    run: async (options) => {
+      received.push(options);
+      return 0;
+    },
+  });
+  assert.equal(received[0]?.model, "opus");
+});
+
+test("readyrun doctor runs the shared check with the loaded config", async () => {
+  const received: DoctorOptions[] = [];
+  const exitCode = await cli({
+    argv: ["doctor"],
+    cwd: "/consumer",
+    stdout: silent,
+    loadConfig: async () => config,
+    doctor: async (options) => {
+      received.push(options);
+      return 0;
+    },
+  });
+  assert.equal(exitCode, 0);
+  assert.equal(received.length, 1);
+  assert.equal(received[0]?.config, config);
+  assert.equal(received[0]?.cwd, "/consumer");
+});
+
+test("doctor refuses when there is no config file at the Consumer root", async () => {
+  await withConsumerRoot(
+    async () => {},
+    async (cwd) => {
+      const chunks: string[] = [];
+      let checked = false;
+      const exitCode = await cli({
+        argv: ["doctor"],
+        cwd,
+        stdout: {
+          write(chunk: string) {
+            chunks.push(chunk);
+            return true;
+          },
+        },
+        doctor: async () => {
+          checked = true;
+          return 0;
+        },
+      });
+      assert.equal(exitCode, 1);
+      assert.equal(checked, false);
+      assert.match(chunks.join(""), /readyrun\.config/);
+    },
+  );
+});
+
+test("ReadyRun loads one config file at the Consumer root, same basename, TypeScript / JS / MJS", async () => {
+  for (const name of ["readyrun.config.ts", "readyrun.config.js", "readyrun.config.mjs"]) {
+    await withConsumerRoot(
+      async (cwd) => {
+        await writeFile(
+          join(cwd, "package.json"),
+          JSON.stringify({ type: "module" }),
+        );
+        await writeFile(join(cwd, name), consumerConfigSource());
+      },
+      async (cwd) => {
+        const loaded = await loadConfig(cwd);
+        assert.equal(loaded.model, "composer-2");
+      },
+    );
+  }
+});
+
+test("ReadyRun does not search other config filenames", async () => {
+  await withConsumerRoot(
+    async (cwd) => {
+      await writeFile(join(cwd, ".readyrunrc.ts"), consumerConfigSource());
+      await writeFile(join(cwd, "readyrun.config.json"), "{}\n");
+      await writeFile(join(cwd, "readyrun.config.cjs"), consumerConfigSource());
+    },
+    async (cwd) => {
+      await assert.rejects(
+        () => loadConfig(cwd),
+        (error: unknown) => {
+          assert.ok(error instanceof Error);
+          assert.match(error.message, /readyrun\.config\.(ts|js|mjs)/);
+          return true;
+        },
+      );
+    },
+  );
+});
+
+test("multiple config files of the same basename are refused", async () => {
+  await withConsumerRoot(
+    async (cwd) => {
+      await writeFile(join(cwd, "readyrun.config.ts"), consumerConfigSource());
+      await writeFile(join(cwd, "readyrun.config.mjs"), consumerConfigSource());
+    },
+    async (cwd) => {
+      await assert.rejects(
+        () => loadConfig(cwd),
+        (error: unknown) => {
+          assert.ok(error instanceof Error);
+          assert.match(error.message, /Multiple config files/);
+          return true;
+        },
+      );
+    },
+  );
+});
+
+test("invoking the readyrun binary with no arguments prints usage", async () => {
+  const bin = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
+  const result = await promisify(execFile)(process.execPath, [bin], {
+    encoding: "utf8",
+  }).then(
+    (ok) => ({ stdout: ok.stdout, status: 0 }),
+    (error: { stdout?: string; code?: number }) => ({
+      stdout: error.stdout ?? "",
+      status: error.code ?? 1,
+    }),
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /Usage: readyrun/);
+});


### PR DESCRIPTION
## Why

Run and Doctor already exist as programmatic entry points, but a Consumer still cannot start them from the terminal. Without a CLI, there is no `readyrun run --max N`, no `readyrun doctor`, and bare invocation cannot print usage instead of a menu — so an unattended loop cannot be started with a known cap, and Init remains the only missing interactive surface after this.

## What

`readyrun` loads one `readyrun.config.ts` (JS or MJS under the same basename) from the Consumer root and translates flags into the same options object `run` and `doctor` already take. A Run without a cap is refused; permissions stay ask unless the operator passes unattended; `--model` overrides the Run.

## How

CLI tests assert the options object handed to those entries, not the loop's internals. `--max` is optional when config already supplies a cap.

Fixes #16


Made with [Cursor](https://cursor.com)