### PR TITLE
#17: Select GitHub as a Tracker Adapter

### DIFF
--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -1,8 +1,13 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import {
   createTrackerAdapter,
   type TrackerAdapter,
 } from "../tracker-adapter.ts";
+import type { Ticket } from "../ticket.ts";
 import { assertKnownKeys } from "../unknown-keys.ts";
+
+const exec = promisify(execFile);
 
 const knownGitHubKeys = new Set([
   "repo",
@@ -20,19 +25,355 @@ export type GitHubTrackerOptions = {
   ids?: string[];
 };
 
-export function github(options: GitHubTrackerOptions): TrackerAdapter {
+export type GitHubRuntime = {
+  fetch?: typeof fetch;
+  token?: string;
+  env?: Record<string, string | undefined>;
+  ghAuthToken?: () => Promise<string | undefined>;
+};
+
+type PageInfo = {
+  hasNextPage: boolean;
+  endCursor: string | null;
+};
+
+type LabelNode = { name: string };
+
+type IssueNode = {
+  number: number;
+  title: string;
+  body: string | null;
+  url: string;
+  labels: { nodes: (LabelNode | null)[] };
+  parent: { number: number } | null;
+  blockedBy?: {
+    nodes: ({
+      number: number;
+      state: "OPEN" | "CLOSED";
+      labels: { nodes: (LabelNode | null)[] };
+    } | null)[];
+  };
+};
+
+const schemaProbeQuery = `query SchemaProbe {
+  __type(name: "Issue") {
+    fields { name }
+  }
+}`;
+
+const labelsQuery = `query Labels($owner: String!, $name: String!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    labels(first: 100, after: $cursor) {
+      pageInfo { hasNextPage endCursor }
+      nodes { name }
+    }
+  }
+}`;
+
+const frontierQuery = `query Frontier($owner: String!, $name: String!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    issues(first: 100, after: $cursor, states: [OPEN]) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        title
+        body
+        url
+        labels(first: 50) { nodes { name } }
+        parent { number }
+        blockedBy(first: 50) {
+          nodes {
+            number
+            state
+            labels(first: 50) { nodes { name } }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+type SchemaProbeData = {
+  __type: { fields: { name: string }[] | null } | null;
+};
+
+type LabelsData = {
+  repository: {
+    labels: { pageInfo: PageInfo; nodes: (LabelNode | null)[] };
+  } | null;
+};
+
+type FrontierData = {
+  repository: {
+    issues: { pageInfo: PageInfo; nodes: (IssueNode | null)[] };
+  } | null;
+};
+
+export function github(
+  options: GitHubTrackerOptions,
+  runtime: GitHubRuntime = {},
+): TrackerAdapter {
   assertKnownKeys(options, knownGitHubKeys);
+  const { owner, name } = splitRepo(options.repo);
+  const http = runtime.fetch ?? fetch;
+
+  async function token(): Promise<string> {
+    if (runtime.token !== undefined && runtime.token.length > 0) {
+      return runtime.token;
+    }
+    const env = runtime.env ?? process.env;
+    const fromEnv = firstNonEmpty(env.GH_TOKEN, env.GITHUB_TOKEN);
+    if (fromEnv !== undefined) {
+      return fromEnv;
+    }
+    const fromGh = await (runtime.ghAuthToken ?? ghAuthToken)();
+    if (fromGh !== undefined && fromGh.length > 0) {
+      return fromGh;
+    }
+    throw new Error("ReadyRun could not authenticate to GitHub");
+  }
+
+  async function graphql<T>(
+    operationName: string,
+    query: string,
+    variables: Record<string, unknown> = {},
+  ): Promise<T> {
+    return githubGraphql<T>(http, await token(), operationName, query, variables);
+  }
+
+  async function rest(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<void> {
+    await githubRest(http, await token(), method, path, body);
+  }
+
+  async function canExpressBlocking(): Promise<boolean> {
+    const data = await graphql<SchemaProbeData>("SchemaProbe", schemaProbeQuery);
+    return data.__type?.fields?.some((field) => field.name === "blockedBy") ??
+      false;
+  }
+
+  async function existingLabels(): Promise<string[]> {
+    const names: string[] = [];
+    let cursor: string | null = null;
+    while (true) {
+      const data: LabelsData = await graphql<LabelsData>("Labels", labelsQuery, {
+        owner,
+        name,
+        cursor,
+      });
+      const connection = data.repository?.labels;
+      if (connection === undefined) {
+        throw new Error(`GitHub repository ${options.repo} was not found`);
+      }
+      for (const node of connection.nodes) {
+        if (node !== null) {
+          names.push(node.name);
+        }
+      }
+      if (!connection.pageInfo.hasNextPage) {
+        break;
+      }
+      cursor = connection.pageInfo.endCursor;
+    }
+    return names;
+  }
+
+  async function inspect() {
+    const [labels, blocking] = await Promise.all([
+      existingLabels(),
+      canExpressBlocking(),
+    ]);
+    return {
+      existingLabels: labels,
+      selectorLabels: options.labels,
+      repository: options.repo,
+      canExpressBlocking: blocking,
+    };
+  }
+
   return Object.assign(
     createTrackerAdapter({
-      inspect() {
-        return Promise.resolve({
-          existingLabels: options.labels,
-          selectorLabels: options.labels,
-          repository: options.repo,
-          canExpressBlocking: true,
-        });
+      async frontier() {
+        const blocking = await canExpressBlocking();
+        if (!blocking) {
+          throw new Error("GitHub cannot express blocking");
+        }
+        const tickets: Ticket[] = [];
+        let cursor: string | null = null;
+        while (true) {
+          const data: FrontierData = await graphql<FrontierData>(
+            "Frontier",
+            frontierQuery,
+            { owner, name, cursor },
+          );
+          const connection = data.repository?.issues;
+          if (connection === undefined) {
+            throw new Error(`GitHub repository ${options.repo} was not found`);
+          }
+          for (const node of connection.nodes) {
+            if (node !== null) {
+              tickets.push(toTicket(node, options.labels));
+            }
+          }
+          if (!connection.pageInfo.hasNextPage) {
+            break;
+          }
+          cursor = connection.pageInfo.endCursor;
+        }
+        return tickets
+          .filter((ticket) => matchesFrontier(ticket, options))
+          .sort((a, b) =>
+            a.id.localeCompare(b.id, undefined, { numeric: true }),
+          );
       },
+      branchName(ticket) {
+        return `readyrun/${ticket.id}`;
+      },
+      async leaveFrontier(ticket) {
+        for (const label of options.labels) {
+          await rest(
+            "DELETE",
+            `/repos/${owner}/${name}/issues/${ticket.id}/labels/${encodeURIComponent(label)}`,
+          );
+        }
+        await rest(
+          "POST",
+          `/repos/${owner}/${name}/issues/${ticket.id}/comments`,
+          {
+            body:
+              "ReadyRun: this Ticket left the Frontier after a successful Worker.",
+          },
+        );
+      },
+      promptCopy(ticket) {
+        return `This Ticket is GitHub #${ticket.id}.\nTitle: ${ticket.title}\n\n${ticket.body}\n\n${ticket.url}`;
+      },
+      inspect,
     }),
     { options },
   );
+}
+
+function matchesFrontier(
+  ticket: Ticket,
+  options: GitHubTrackerOptions,
+): boolean {
+  if (!options.labels.every((label) => ticket.labels.includes(label))) {
+    return false;
+  }
+  if (options.parent !== undefined && ticket.parent !== options.parent) {
+    return false;
+  }
+  if (options.ids !== undefined && !options.ids.includes(ticket.id)) {
+    return false;
+  }
+  return ticket.blockedBy.length === 0;
+}
+
+function toTicket(node: IssueNode, selectorLabels: readonly string[]): Ticket {
+  const labels = names(node.labels.nodes);
+  const blockedBy = (node.blockedBy?.nodes ?? []).flatMap((blocker) => {
+    if (blocker === null) {
+      return [];
+    }
+    // Success drops labels and does not close, so an open blocker only still
+    // blocks while it matches the selector.
+    const stillBlocking = blocker.state === "OPEN" &&
+      selectorLabels.every((label) => names(blocker.labels.nodes).includes(label));
+    return stillBlocking ? [String(blocker.number)] : [];
+  });
+  return {
+    id: String(node.number),
+    title: node.title,
+    body: node.body ?? "",
+    url: node.url,
+    labels,
+    blockedBy,
+    parent: node.parent === null ? undefined : String(node.parent.number),
+  };
+}
+
+function names(nodes: (LabelNode | null)[]): string[] {
+  return nodes.flatMap((node) => node === null ? [] : [node.name]);
+}
+
+function splitRepo(repo: string): { owner: string; name: string } {
+  const trimmed = repo.trim().replace(/\/+$/, "").replace(/\.git$/i, "");
+  const [owner, name, ...rest] = trimmed.split("/");
+  if (owner === undefined || name === undefined || rest.length > 0) {
+    throw new Error(`GitHub repo must be owner/name, got ${repo}`);
+  }
+  return { owner, name };
+}
+
+function firstNonEmpty(
+  ...values: (string | undefined)[]
+): string | undefined {
+  return values.find((value) => value !== undefined && value.length > 0);
+}
+
+const githubHeaders = (token: string): Record<string, string> => ({
+  Authorization: `Bearer ${token}`,
+  Accept: "application/vnd.github+json",
+  "Content-Type": "application/json",
+  "User-Agent": "readyrun",
+  "X-GitHub-Api-Version": "2022-11-28",
+});
+
+async function githubGraphql<T>(
+  http: typeof fetch,
+  token: string,
+  operationName: string,
+  query: string,
+  variables: Record<string, unknown>,
+): Promise<T> {
+  const response = await http("https://api.github.com/graphql", {
+    method: "POST",
+    headers: githubHeaders(token),
+    body: JSON.stringify({ query, variables, operationName }),
+  });
+  const payload = await response.json() as {
+    data?: T;
+    errors?: { message: string }[];
+  };
+  if (!response.ok) {
+    throw new Error(`GitHub GraphQL HTTP ${response.status}`);
+  }
+  if (payload.errors !== undefined && payload.errors.length > 0) {
+    throw new Error(payload.errors[0]?.message ?? "GitHub GraphQL error");
+  }
+  if (payload.data === undefined) {
+    throw new Error("GitHub GraphQL returned no data");
+  }
+  return payload.data;
+}
+
+async function githubRest(
+  http: typeof fetch,
+  token: string,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<void> {
+  const response = await http(`https://api.github.com${path}`, {
+    method,
+    headers: githubHeaders(token),
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub REST HTTP ${response.status}`);
+  }
+}
+
+async function ghAuthToken(): Promise<string | undefined> {
+  try {
+    const { stdout } = await exec("gh", ["auth", "token"], { encoding: "utf8" });
+    const token = stdout.trim();
+    return token.length === 0 ? undefined : token;
+  } catch {
+    return undefined;
+  }
 }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -20,7 +20,13 @@ async function check(
   if (typeof config.model !== "string" || config.model.length === 0) {
     failures.push("missing model default");
   }
-  const inspect = await config.tracker.inspect();
+  let inspect;
+  try {
+    inspect = await config.tracker.inspect();
+  } catch (error) {
+    failures.push(error instanceof Error ? error.message : String(error));
+    return failures;
+  }
   for (const label of inspect.selectorLabels) {
     if (!inspect.existingLabels.includes(label)) {
       failures.push(`label "${label}" does not exist on the Tracker`);

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -2,10 +2,11 @@ import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { test } from "node:test";
 import { promisify } from "node:util";
-import { defineConfig, custom, doctor, github, run, UnknownConfigKeyError } from "../src/mod.ts";
+import { defineConfig, custom, doctor, run, UnknownConfigKeyError } from "../src/mod.ts";
 import type { ReadyRunConfig } from "../src/mod.ts";
 import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
 import { createTrackerAdapter } from "../src/tracker-adapter.ts";
+import { githubFromWorld } from "./github-http-fixture.ts";
 import { ticket } from "./tracker-adapter-contract.ts";
 import { throwawayRepo } from "./throwaway-repo.ts";
 
@@ -110,12 +111,13 @@ test("a configured repository that is not the git remote fails Doctor and a Run 
     "git@github.com:other/place.git",
   ]);
   const chunks: string[] = [];
+  const { adapter } = githubFromWorld({
+    tickets: [ticket({ id: "52" })],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+  });
   const config = defineConfig({
-    tracker: github({
-      repo: "acme/widgets",
-      ready: "unblocked",
-      labels: ["ready-for-agent"],
-    }),
+    tracker: adapter,
     worker,
     model: "composer-2",
   });

--- a/test/github-contract.test.ts
+++ b/test/github-contract.test.ts
@@ -1,0 +1,6 @@
+import { githubFromWorld } from "./github-http-fixture.ts";
+import { trackerAdapterContract } from "./tracker-adapter-contract.ts";
+
+trackerAdapterContract("GitHub Tracker Adapter", (world) => {
+  return githubFromWorld(world).adapter;
+});

--- a/test/github-http-fixture.ts
+++ b/test/github-http-fixture.ts
@@ -1,0 +1,246 @@
+import { github, type GitHubTrackerOptions } from "../src/mod.ts";
+import type { MemoryTrackerOptions } from "../src/testing/memory-tracker.ts";
+
+export type GitHubRecordedRequest = {
+  method: string;
+  url: string;
+  body: string | undefined;
+};
+
+type FixtureIssue = {
+  number: number;
+  title: string;
+  body: string;
+  url: string;
+  labels: string[];
+  blockedBy: number[];
+  parent: number | undefined;
+  state: "OPEN" | "CLOSED";
+  comments: string[];
+};
+
+export type GitHubHttpFixture = {
+  fetch: typeof fetch;
+  requests: readonly GitHubRecordedRequest[];
+};
+
+export function githubFromWorld(
+  world: MemoryTrackerOptions,
+  repo = "acme/widgets",
+): { adapter: ReturnType<typeof github>; fixture: GitHubHttpFixture } {
+  const fixture = githubHttpFixture({ repo, ...world });
+  const options: GitHubTrackerOptions = {
+    repo,
+    ready: world.ready,
+    labels: world.labels,
+    parent: world.parent,
+    ids: world.ids,
+  };
+  return {
+    fixture,
+    adapter: github(options, { token: "test-token", fetch: fixture.fetch }),
+  };
+}
+
+export function githubHttpFixture(
+  world: MemoryTrackerOptions & { repo: string },
+): GitHubHttpFixture {
+  const issues: FixtureIssue[] = world.tickets.map((ticket) => ({
+    number: Number(ticket.id),
+    title: ticket.title,
+    body: ticket.body,
+    url: ticket.url,
+    labels: [...ticket.labels],
+    blockedBy: ticket.blockedBy.map((id) => Number(id)),
+    parent: ticket.parent === undefined ? undefined : Number(ticket.parent),
+    state: "OPEN",
+    comments: [],
+  }));
+  const existingLabels = world.existingLabels ?? [
+    ...new Set([
+      ...world.labels,
+      ...world.tickets.flatMap((ticket) => ticket.labels),
+    ]),
+  ];
+  const canExpressBlocking = world.canExpressBlocking ?? true;
+  const requests: GitHubRecordedRequest[] = [];
+  const [owner, name] = world.repo.split("/");
+
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = requestUrl(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    const body = typeof init?.body === "string" ? init.body : undefined;
+    requests.push({ method, url, body });
+
+    const headers = headerMap(init?.headers);
+    if (headers.authorization !== "Bearer test-token") {
+      return jsonResponse({ message: "Bad credentials" }, 401);
+    }
+
+    if (url === "https://api.github.com/graphql") {
+      return graphqlResponse(
+        body,
+        issues,
+        existingLabels,
+        canExpressBlocking,
+        owner,
+        name,
+      );
+    }
+
+    const deleted = url.match(
+      /^https:\/\/api\.github\.com\/repos\/([^/]+)\/([^/]+)\/issues\/(\d+)\/labels\/(.+)$/,
+    );
+    if (method === "DELETE" && deleted !== null) {
+      const issue = issues.find((issue) => String(issue.number) === deleted[3]);
+      const label = decodeURIComponent(deleted[4] ?? "");
+      if (issue !== undefined) {
+        issue.labels = issue.labels.filter((name) => name !== label);
+      }
+      return jsonResponse({}, 200);
+    }
+
+    const commented = url.match(
+      /^https:\/\/api\.github\.com\/repos\/([^/]+)\/([^/]+)\/issues\/(\d+)\/comments$/,
+    );
+    if (method === "POST" && commented !== null) {
+      const issue = issues.find((issue) => String(issue.number) === commented[3]);
+      const parsed = body === undefined ? {} : JSON.parse(body) as { body?: string };
+      if (issue !== undefined && parsed.body !== undefined) {
+        issue.comments.push(parsed.body);
+      }
+      return jsonResponse({ id: 1 }, 201);
+    }
+
+    return jsonResponse({ message: "Not Found" }, 404);
+  };
+
+  return { fetch: fetchImpl, requests };
+}
+
+function requestUrl(input: string | URL | Request): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
+  return input.url;
+}
+
+function headerMap(headers: RequestInit["headers"]): Record<string, string> {
+  const result: Record<string, string> = {};
+  if (headers === undefined) {
+    return result;
+  }
+  if (headers instanceof Headers) {
+    for (const [key, value] of headers.entries()) {
+      result[key.toLowerCase()] = value;
+    }
+    return result;
+  }
+  if (Array.isArray(headers)) {
+    for (const pair of headers) {
+      result[pair[0].toLowerCase()] = pair[1];
+    }
+    return result;
+  }
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === "string") {
+      result[key.toLowerCase()] = value;
+    }
+  }
+  return result;
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function graphqlResponse(
+  body: string | undefined,
+  issues: FixtureIssue[],
+  existingLabels: readonly string[],
+  canExpressBlocking: boolean,
+  owner: string | undefined,
+  name: string | undefined,
+): Response {
+  const parsed = body === undefined
+    ? { operationName: "", variables: {} }
+    : JSON.parse(body) as {
+      operationName?: string;
+      query?: string;
+      variables?: { owner?: string; name?: string };
+    };
+  const operation = parsed.operationName ?? "";
+  const variables = parsed.variables ?? {};
+  if (
+    variables.owner !== undefined &&
+    variables.name !== undefined &&
+    (variables.owner !== owner || variables.name !== name)
+  ) {
+    return jsonResponse({ data: { repository: null } }, 200);
+  }
+
+  if (operation === "SchemaProbe") {
+    const fields = canExpressBlocking
+      ? [{ name: "blockedBy" }, { name: "title" }]
+      : [{ name: "title" }];
+    return jsonResponse({ data: { __type: { fields } } }, 200);
+  }
+
+  if (operation === "Labels") {
+    return jsonResponse({
+      data: {
+        repository: {
+          labels: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: existingLabels.map((labelName) => ({ name: labelName })),
+          },
+        },
+      },
+    }, 200);
+  }
+
+  if (operation === "Frontier") {
+    const nodes = issues
+      .filter((issue) => issue.state === "OPEN")
+      .map((issue) => ({
+        number: issue.number,
+        title: issue.title,
+        body: issue.body,
+        url: issue.url,
+        labels: { nodes: issue.labels.map((labelName) => ({ name: labelName })) },
+        parent: issue.parent === undefined ? null : { number: issue.parent },
+        blockedBy: {
+          nodes: issue.blockedBy.map((number) => {
+            const blocker = issues.find((candidate) => candidate.number === number);
+            return {
+              number,
+              state: blocker?.state ?? "OPEN",
+              labels: {
+                nodes: (blocker?.labels ?? []).map((labelName) => ({ name: labelName })),
+              },
+            };
+          }),
+        },
+      }));
+    return jsonResponse({
+      data: {
+        repository: {
+          issues: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes,
+          },
+        },
+      },
+    }, 200);
+  }
+
+  return jsonResponse({
+    errors: [{ message: `Unknown GraphQL operation ${operation}` }],
+  }, 200);
+}

--- a/test/github-live.test.ts
+++ b/test/github-live.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { github } from "../src/mod.ts";
+
+const live = process.env.READYRUN_GITHUB_LIVE === "1";
+
+test("live credentialed GitHub inspect is opt-in, not required for CI", {
+  skip: !live,
+}, async () => {
+  const repo = process.env.READYRUN_GITHUB_REPO ?? "MichaelBuss/readyrun";
+  const adapter = github({
+    repo,
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+  });
+  const inspect = await adapter.inspect();
+  assert.equal(inspect.repository, repo);
+  assert.deepEqual(inspect.selectorLabels, ["ready-for-agent"]);
+  assert.ok(
+    inspect.existingLabels.includes("ready-for-agent"),
+    "expected the live repository to have the ready-for-agent label",
+  );
+});

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -1,0 +1,236 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { test } from "node:test";
+import { promisify } from "node:util";
+import { defineConfig, doctor, github, run } from "../src/mod.ts";
+import { recordingWorker } from "../src/testing/mod.ts";
+import { githubFromWorld, githubHttpFixture } from "./github-http-fixture.ts";
+import { ticket } from "./tracker-adapter-contract.ts";
+import { throwawayRepo } from "./throwaway-repo.ts";
+
+const exec = promisify(execFile);
+const silent = { write(_chunk?: string) { return true; } };
+
+const world = {
+  tickets: [ticket({ id: "52" })],
+  ready: "unblocked" as const,
+  labels: ["ready-for-agent"],
+};
+
+async function repoWithOrigin(url = "git@github.com:acme/widgets.git") {
+  const repo = await throwawayRepo();
+  await exec("git", ["-C", repo.cwd, "remote", "add", "origin", url]);
+  return repo;
+}
+
+test("success drops the frontier label, comments, and does not close", async () => {
+  const { adapter, fixture } = githubFromWorld(world);
+  const frontier = await adapter.frontier();
+  const finished = frontier[0];
+  assert.ok(finished);
+  await adapter.leaveFrontier(finished);
+
+  assert.ok(
+    fixture.requests.some(
+      (request) =>
+        request.method === "DELETE" &&
+        request.url.endsWith("/issues/52/labels/ready-for-agent"),
+    ),
+  );
+  const comments = fixture.requests.filter(
+    (request) =>
+      request.method === "POST" && request.url.endsWith("/issues/52/comments"),
+  );
+  assert.equal(comments.length, 1);
+  assert.match(comments[0]?.body ?? "", /left the Frontier/);
+  assert.equal(
+    fixture.requests.filter((request) => request.method === "PATCH").length,
+    0,
+  );
+  assert.ok(
+    !fixture.requests.some((request) =>
+      (request.body ?? "").includes("closeIssue") ||
+      (request.body ?? "").includes("\"state\":\"closed\"")
+    ),
+  );
+});
+
+test("inspect reports labels that exist on GitHub, not the selector", async () => {
+  const { adapter } = githubFromWorld({
+    tickets: [ticket({ id: "52" })],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+    existingLabels: ["ready-for-agent", "bug"],
+  });
+  const inspect = await adapter.inspect();
+  assert.deepEqual(inspect.existingLabels, ["ready-for-agent", "bug"]);
+  assert.deepEqual(inspect.selectorLabels, ["ready-for-agent"]);
+  assert.equal(inspect.repository, "acme/widgets");
+  assert.equal(inspect.canExpressBlocking, true);
+});
+
+test("Doctor fails when a named GitHub label does not exist on the repository", async () => {
+  const repo = await repoWithOrigin();
+  const { adapter } = githubFromWorld({
+    tickets: [ticket({ id: "52" })],
+    ready: "unblocked",
+    labels: ["does-not-exist"],
+    existingLabels: ["ready-for-agent"],
+  });
+  const chunks: string[] = [];
+  try {
+    const exit = await doctor({
+      config: defineConfig({
+        tracker: adapter,
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(exit, 1);
+    assert.match(
+      chunks.join(""),
+      /Doctor: label "does-not-exist" does not exist on the Tracker/,
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("Doctor fails when GitHub cannot express blocking", async () => {
+  const repo = await repoWithOrigin();
+  const { adapter } = githubFromWorld({
+    ...world,
+    canExpressBlocking: false,
+  });
+  const chunks: string[] = [];
+  try {
+    const exit = await doctor({
+      config: defineConfig({
+        tracker: adapter,
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(exit, 1);
+    assert.match(
+      chunks.join(""),
+      /Doctor: Tracker cannot express blocking; unblocked ordering is a lie/,
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("ReadyRun authenticates to GitHub via GH_TOKEN; the Worker is not given the token", async () => {
+  const repo = await repoWithOrigin();
+  const fixture = githubHttpFixture({ repo: "acme/widgets", ...world });
+  const adapter = github(
+    {
+      repo: "acme/widgets",
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+    },
+    {
+      env: { GH_TOKEN: "test-token" },
+      ghAuthToken: () => Promise.reject(new Error("gh should not be called")),
+      fetch: fixture.fetch,
+    },
+  );
+  const worker = recordingWorker({ exitCode: 0 });
+  try {
+    const exit = await run({
+      config: defineConfig({
+        tracker: adapter,
+        worker,
+        model: "composer-2",
+      }),
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+    assert.equal(exit, 0);
+    assert.equal(worker.spawns.length, 1);
+    assert.equal(JSON.stringify(worker.spawns[0]).includes("test-token"), false);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("ReadyRun authenticates to GitHub via gh when no token is in the environment", async () => {
+  const fixture = githubHttpFixture({ repo: "acme/widgets", ...world });
+  const adapter = github(
+    {
+      repo: "acme/widgets",
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+    },
+    {
+      env: {},
+      ghAuthToken: () => Promise.resolve("test-token"),
+      fetch: fixture.fetch,
+    },
+  );
+  const frontier = await adapter.frontier();
+  assert.deepEqual(frontier.map((item) => item.id), ["52"]);
+});
+
+test("Doctor fails when ReadyRun cannot authenticate to GitHub", async () => {
+  const repo = await repoWithOrigin();
+  const adapter = github(
+    {
+      repo: "acme/widgets",
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+    },
+    {
+      env: {},
+      ghAuthToken: () => Promise.resolve(undefined),
+    },
+  );
+  const chunks: string[] = [];
+  try {
+    const exit = await doctor({
+      config: defineConfig({
+        tracker: adapter,
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(exit, 1);
+    assert.match(
+      chunks.join(""),
+      /Doctor: ReadyRun could not authenticate to GitHub/,
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("the Worker prompt names this Ticket as GitHub and the Ticket id", async () => {
+  const { adapter } = githubFromWorld(world);
+  const [picked] = await adapter.frontier();
+  assert.ok(picked);
+  assert.match(adapter.promptCopy(picked), /GitHub #52/);
+  assert.match(adapter.promptCopy(picked), /https:\/\/example\.test\/52/);
+});


### PR DESCRIPTION
## Why

A Consumer can already write `github()` in `defineConfig`, but that factory did not talk to GitHub. Without a real Tracker Adapter, Doctor cannot check labels or blocking against the repository, a Run cannot pick unblocked Tickets by issue number, and success cannot drop the frontier label so the next Ticket becomes eligible.

## What

`github()` now evaluates the Frontier on GitHub, authenticates as ReadyRun (`GH_TOKEN` / `GITHUB_TOKEN` / `gh auth token`), and on success drops the selector labels, comments, and does not close. Doctor fails on a missing label, repo ≠ remote, or blocking the Tracker cannot express.

## How

The shared Tracker Adapter contract suite runs against an HTTP fixture at the fetch boundary. Live inspect is opt-in (`READYRUN_GITHUB_LIVE=1`), not CI.

## Workarounds

An open blocker still blocks only while it matches the Frontier selector. Success does not close, so GitHub's native "blocked by any open issue" would never release waiters. An open blocker that never had the frontier label will not hold the Frontier; that is the cost of leave-Frontier-without-closing.

Fixes #17


Made with [Cursor](https://cursor.com)