### PR TITLE
#18: Select Linear as a Tracker Adapter

### DIFF
--- a/src/adapters/linear.ts
+++ b/src/adapters/linear.ts
@@ -201,85 +201,54 @@ export function linear(
       false;
   }
 
-  async function existingLabels(): Promise<string[]> {
-    const names: string[] = [];
+  async function paginate<T, N>(
+    operationName: string,
+    query: string,
+    connection: (data: T) => { pageInfo: PageInfo; nodes: (N | null)[] },
+  ): Promise<N[]> {
+    const nodes: N[] = [];
     let cursor: string | null = null;
     while (true) {
-      const data: IssueLabelsData = await graphql<IssueLabelsData>(
-        "IssueLabels",
-        issueLabelsQuery,
-        { cursor },
-      );
-      for (const node of data.issueLabels.nodes) {
+      const data: T = await graphql<T>(operationName, query, { cursor });
+      const page = connection(data);
+      for (const node of page.nodes) {
         if (node !== null) {
-          names.push(node.name);
+          nodes.push(node);
         }
       }
-      if (!data.issueLabels.pageInfo.hasNextPage) {
+      if (!page.pageInfo.hasNextPage) {
         break;
       }
-      cursor = data.issueLabels.pageInfo.endCursor;
+      cursor = page.pageInfo.endCursor;
     }
-    return names;
-  }
-
-  async function existingStates(): Promise<StateNode[]> {
-    const states: StateNode[] = [];
-    let cursor: string | null = null;
-    while (true) {
-      const data: WorkflowStatesData = await graphql<WorkflowStatesData>(
-        "WorkflowStates",
-        workflowStatesQuery,
-        { cursor },
-      );
-      for (const node of data.workflowStates.nodes) {
-        if (node !== null) {
-          states.push(node);
-        }
-      }
-      if (!data.workflowStates.pageInfo.hasNextPage) {
-        break;
-      }
-      cursor = data.workflowStates.pageInfo.endCursor;
-    }
-    return states;
-  }
-
-  async function existingProjects(): Promise<string[]> {
-    const names: string[] = [];
-    let cursor: string | null = null;
-    while (true) {
-      const data: ProjectsData = await graphql<ProjectsData>(
-        "Projects",
-        projectsQuery,
-        { cursor },
-      );
-      for (const node of data.projects.nodes) {
-        if (node !== null) {
-          names.push(node.name);
-        }
-      }
-      if (!data.projects.pageInfo.hasNextPage) {
-        break;
-      }
-      cursor = data.projects.pageInfo.endCursor;
-    }
-    return names;
+    return nodes;
   }
 
   async function inspect() {
     const [labels, states, projects, blocking] = await Promise.all([
-      existingLabels(),
-      existingStates(),
-      existingProjects(),
+      paginate<IssueLabelsData, LabelNode>(
+        "IssueLabels",
+        issueLabelsQuery,
+        (data) => data.issueLabels,
+      ),
+      paginate<WorkflowStatesData, StateNode>(
+        "WorkflowStates",
+        workflowStatesQuery,
+        (data) => data.workflowStates,
+      ),
+      paginate<ProjectsData, ProjectNode>(
+        "Projects",
+        projectsQuery,
+        (data) => data.projects,
+      ),
       canExpressBlocking(),
     ]);
     return {
-      existingLabels: labels,
+      existingLabels: labels.map((label) => label.name),
       selectorLabels: options.label === undefined ? [] : [options.label],
       existingStates: states.map((state) => state.name),
       selectorState: options.state,
-      existingProjects: projects,
+      existingProjects: projects.map((project) => project.name),
       selectorProject: options.project,
       canExpressBlocking: blocking,
     };
@@ -292,29 +261,22 @@ export function linear(
         if (!blocking) {
           throw new Error("Linear cannot express blocking");
         }
-        const tickets: Ticket[] = [];
         suggestedBranches.clear();
-        let cursor: string | null = null;
-        while (true) {
-          const data: FrontierData = await graphql<FrontierData>(
-            "Frontier",
-            frontierQuery,
-            { cursor },
-          );
-          for (const node of data.issues.nodes) {
-            if (node === null || !matchesFrontier(node, options)) {
-              continue;
-            }
-            const ticket = toTicket(node);
-            tickets.push(ticket);
-            if (node.branchName !== null && node.branchName.length > 0) {
-              suggestedBranches.set(ticket.id, node.branchName);
-            }
+        const issues = await paginate<FrontierData, IssueNode>(
+          "Frontier",
+          frontierQuery,
+          (data) => data.issues,
+        );
+        const tickets: Ticket[] = [];
+        for (const node of issues) {
+          if (!matchesFrontier(node, options)) {
+            continue;
           }
-          if (!data.issues.pageInfo.hasNextPage) {
-            break;
+          const ticket = toTicket(node);
+          tickets.push(ticket);
+          if (node.branchName !== null && node.branchName.length > 0) {
+            suggestedBranches.set(ticket.id, node.branchName);
           }
-          cursor = data.issues.pageInfo.endCursor;
         }
         return tickets.sort((a, b) =>
           a.id.localeCompare(b.id, undefined, { numeric: true }),

--- a/src/adapters/linear.ts
+++ b/src/adapters/linear.ts
@@ -2,6 +2,7 @@ import {
   createTrackerAdapter,
   type TrackerAdapter,
 } from "../tracker-adapter.ts";
+import type { Ticket } from "../ticket.ts";
 import { assertKnownKeys } from "../unknown-keys.ts";
 
 const knownLinearKeys = new Set([
@@ -22,7 +23,435 @@ export type LinearTrackerOptions = {
   ids?: string[];
 };
 
-export function linear(options: LinearTrackerOptions): TrackerAdapter {
+export type LinearRuntime = {
+  fetch?: typeof fetch;
+  token?: string;
+  env?: Record<string, string | undefined>;
+};
+
+type PageInfo = {
+  hasNextPage: boolean;
+  endCursor: string | null;
+};
+
+type LabelNode = { name: string };
+type ProjectNode = { name: string };
+type StateNode = {
+  id: string;
+  name: string;
+  type: string;
+};
+
+type IssueNode = {
+  identifier: string;
+  title: string;
+  description: string | null;
+  url: string;
+  branchName: string | null;
+  state: StateNode;
+  labels: { nodes: (LabelNode | null)[] };
+  project: ProjectNode | null;
+  parent: { identifier: string } | null;
+  inverseRelations?: {
+    nodes: ({
+      type: string;
+      issue: {
+        identifier: string;
+        state: { name: string; type: string };
+      };
+    } | null)[];
+  };
+};
+
+const schemaProbeQuery = `query SchemaProbe {
+  __type(name: "Issue") {
+    fields { name }
+  }
+}`;
+
+const issueLabelsQuery = `query IssueLabels($cursor: String) {
+  issueLabels(first: 100, after: $cursor) {
+    pageInfo { hasNextPage endCursor }
+    nodes { name }
+  }
+}`;
+
+const workflowStatesQuery = `query WorkflowStates($cursor: String) {
+  workflowStates(first: 100, after: $cursor) {
+    pageInfo { hasNextPage endCursor }
+    nodes { id name type }
+  }
+}`;
+
+const projectsQuery = `query Projects($cursor: String) {
+  projects(first: 100, after: $cursor) {
+    pageInfo { hasNextPage endCursor }
+    nodes { name }
+  }
+}`;
+
+const frontierQuery = `query Frontier($cursor: String) {
+  issues(first: 100, after: $cursor) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      identifier
+      title
+      description
+      url
+      branchName
+      state { id name type }
+      labels(first: 50) { nodes { name } }
+      project { name }
+      parent { identifier }
+      inverseRelations(first: 50) {
+        nodes {
+          type
+          issue {
+            identifier
+            state { name type }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const issueStatesQuery = `query IssueStates($id: String!) {
+  issue(id: $id) {
+    id
+    team {
+      states {
+        nodes { id name type }
+      }
+    }
+  }
+}`;
+
+const leaveFrontierMutation = `mutation LeaveFrontier($id: String!, $input: IssueUpdateInput!) {
+  issueUpdate(id: $id, input: $input) {
+    success
+    issue { identifier state { name type } }
+  }
+}`;
+
+type SchemaProbeData = {
+  __type: { fields: { name: string }[] | null } | null;
+};
+
+type IssueLabelsData = {
+  issueLabels: { pageInfo: PageInfo; nodes: (LabelNode | null)[] };
+};
+
+type WorkflowStatesData = {
+  workflowStates: { pageInfo: PageInfo; nodes: (StateNode | null)[] };
+};
+
+type ProjectsData = {
+  projects: { pageInfo: PageInfo; nodes: (ProjectNode | null)[] };
+};
+
+type FrontierData = {
+  issues: { pageInfo: PageInfo; nodes: (IssueNode | null)[] };
+};
+
+type IssueStatesData = {
+  issue: {
+    team: { states: { nodes: (StateNode | null)[] } };
+  } | null;
+};
+
+export function linear(
+  options: LinearTrackerOptions,
+  runtime: LinearRuntime = {},
+): TrackerAdapter {
   assertKnownKeys(options, knownLinearKeys);
-  return Object.assign(createTrackerAdapter(), { options });
+  if (
+    options.state === undefined &&
+    options.label === undefined &&
+    options.project === undefined
+  ) {
+    throw new Error("Linear Frontier needs a state, label, or project");
+  }
+  const http = runtime.fetch ?? fetch;
+  const suggestedBranches = new Map<string, string>();
+
+  async function token(): Promise<string> {
+    if (runtime.token !== undefined && runtime.token.length > 0) {
+      return runtime.token;
+    }
+    const env = runtime.env ?? process.env;
+    const fromEnv = env.LINEAR_API_KEY;
+    if (fromEnv !== undefined && fromEnv.length > 0) {
+      return fromEnv;
+    }
+    throw new Error("ReadyRun could not authenticate to Linear");
+  }
+
+  async function graphql<T>(
+    operationName: string,
+    query: string,
+    variables: Record<string, unknown> = {},
+  ): Promise<T> {
+    return linearGraphql<T>(http, await token(), operationName, query, variables);
+  }
+
+  async function canExpressBlocking(): Promise<boolean> {
+    const data = await graphql<SchemaProbeData>("SchemaProbe", schemaProbeQuery);
+    return data.__type?.fields?.some((field) => field.name === "inverseRelations") ??
+      false;
+  }
+
+  async function existingLabels(): Promise<string[]> {
+    const names: string[] = [];
+    let cursor: string | null = null;
+    while (true) {
+      const data: IssueLabelsData = await graphql<IssueLabelsData>(
+        "IssueLabels",
+        issueLabelsQuery,
+        { cursor },
+      );
+      for (const node of data.issueLabels.nodes) {
+        if (node !== null) {
+          names.push(node.name);
+        }
+      }
+      if (!data.issueLabels.pageInfo.hasNextPage) {
+        break;
+      }
+      cursor = data.issueLabels.pageInfo.endCursor;
+    }
+    return names;
+  }
+
+  async function existingStates(): Promise<StateNode[]> {
+    const states: StateNode[] = [];
+    let cursor: string | null = null;
+    while (true) {
+      const data: WorkflowStatesData = await graphql<WorkflowStatesData>(
+        "WorkflowStates",
+        workflowStatesQuery,
+        { cursor },
+      );
+      for (const node of data.workflowStates.nodes) {
+        if (node !== null) {
+          states.push(node);
+        }
+      }
+      if (!data.workflowStates.pageInfo.hasNextPage) {
+        break;
+      }
+      cursor = data.workflowStates.pageInfo.endCursor;
+    }
+    return states;
+  }
+
+  async function existingProjects(): Promise<string[]> {
+    const names: string[] = [];
+    let cursor: string | null = null;
+    while (true) {
+      const data: ProjectsData = await graphql<ProjectsData>(
+        "Projects",
+        projectsQuery,
+        { cursor },
+      );
+      for (const node of data.projects.nodes) {
+        if (node !== null) {
+          names.push(node.name);
+        }
+      }
+      if (!data.projects.pageInfo.hasNextPage) {
+        break;
+      }
+      cursor = data.projects.pageInfo.endCursor;
+    }
+    return names;
+  }
+
+  async function inspect() {
+    const [labels, states, projects, blocking] = await Promise.all([
+      existingLabels(),
+      existingStates(),
+      existingProjects(),
+      canExpressBlocking(),
+    ]);
+    return {
+      existingLabels: labels,
+      selectorLabels: options.label === undefined ? [] : [options.label],
+      existingStates: states.map((state) => state.name),
+      selectorState: options.state,
+      existingProjects: projects,
+      selectorProject: options.project,
+      canExpressBlocking: blocking,
+    };
+  }
+
+  return Object.assign(
+    createTrackerAdapter({
+      async frontier() {
+        const blocking = await canExpressBlocking();
+        if (!blocking) {
+          throw new Error("Linear cannot express blocking");
+        }
+        const tickets: Ticket[] = [];
+        suggestedBranches.clear();
+        let cursor: string | null = null;
+        while (true) {
+          const data: FrontierData = await graphql<FrontierData>(
+            "Frontier",
+            frontierQuery,
+            { cursor },
+          );
+          for (const node of data.issues.nodes) {
+            if (node === null || !matchesFrontier(node, options)) {
+              continue;
+            }
+            const ticket = toTicket(node);
+            tickets.push(ticket);
+            if (node.branchName !== null && node.branchName.length > 0) {
+              suggestedBranches.set(ticket.id, node.branchName);
+            }
+          }
+          if (!data.issues.pageInfo.hasNextPage) {
+            break;
+          }
+          cursor = data.issues.pageInfo.endCursor;
+        }
+        return tickets.sort((a, b) =>
+          a.id.localeCompare(b.id, undefined, { numeric: true }),
+        );
+      },
+      branchName(ticket) {
+        return suggestedBranches.get(ticket.id) ?? `readyrun/${ticket.id}`;
+      },
+      async leaveFrontier(ticket) {
+        const data = await graphql<IssueStatesData>(
+          "IssueStates",
+          issueStatesQuery,
+          { id: ticket.id },
+        );
+        const states = data.issue?.team.states.nodes ?? [];
+        const inReview = states.find((state): state is StateNode =>
+          state !== null && state.name === "In Review" &&
+          state.type !== "completed"
+        );
+        if (inReview === undefined) {
+          throw new Error(
+            `Linear has no In Review state for Ticket ${ticket.id}`,
+          );
+        }
+        await graphql("LeaveFrontier", leaveFrontierMutation, {
+          id: ticket.id,
+          input: { stateId: inReview.id },
+        });
+      },
+      promptCopy(ticket) {
+        return `This Ticket is Linear ${ticket.id}.\nTitle: ${ticket.title}\n\n${ticket.body}\n\n${ticket.url}`;
+      },
+      inspect,
+    }),
+    { options },
+  );
+}
+
+function matchesFrontier(
+  node: IssueNode,
+  options: LinearTrackerOptions,
+): boolean {
+  if (options.state === undefined && hasLeftFrontier(node.state)) {
+    return false;
+  }
+  if (
+    options.label !== undefined &&
+    !names(node.labels.nodes).includes(options.label)
+  ) {
+    return false;
+  }
+  if (options.state !== undefined && node.state.name !== options.state) {
+    return false;
+  }
+  if (
+    options.project !== undefined &&
+    (node.project === null || node.project.name !== options.project)
+  ) {
+    return false;
+  }
+  if (
+    options.parent !== undefined &&
+    (node.parent === null || node.parent.identifier !== options.parent)
+  ) {
+    return false;
+  }
+  if (options.ids !== undefined && !options.ids.includes(node.identifier)) {
+    return false;
+  }
+  return blockedBy(node).length === 0;
+}
+
+function blockedBy(node: IssueNode): string[] {
+  return (node.inverseRelations?.nodes ?? []).flatMap((relation) => {
+    if (relation === null || relation.type !== "blocks") {
+      return [];
+    }
+    const blocker = relation.issue;
+    if (hasLeftFrontier(blocker.state)) {
+      return [];
+    }
+    return [blocker.identifier];
+  });
+}
+
+function toTicket(node: IssueNode): Ticket {
+  return {
+    id: node.identifier,
+    title: node.title,
+    body: node.description ?? "",
+    url: node.url,
+    labels: names(node.labels.nodes),
+    blockedBy: blockedBy(node),
+    parent: node.parent === null ? undefined : node.parent.identifier,
+  };
+}
+
+function hasLeftFrontier(state: { name: string; type: string }): boolean {
+  return state.name === "In Review" ||
+    state.type === "completed" ||
+    state.type === "canceled";
+}
+
+function names(nodes: (LabelNode | null)[]): string[] {
+  return nodes.flatMap((node) => node === null ? [] : [node.name]);
+}
+
+async function linearGraphql<T>(
+  http: typeof fetch,
+  token: string,
+  operationName: string,
+  query: string,
+  variables: Record<string, unknown>,
+): Promise<T> {
+  const response = await http("https://api.linear.app/graphql", {
+    method: "POST",
+    headers: {
+      Authorization: token,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables, operationName }),
+  });
+  const payload = await response.json() as {
+    data?: T;
+    errors?: { message: string }[];
+  };
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new Error("ReadyRun could not authenticate to Linear");
+    }
+    throw new Error(`Linear GraphQL HTTP ${response.status}`);
+  }
+  if (payload.errors !== undefined && payload.errors.length > 0) {
+    throw new Error(payload.errors[0]?.message ?? "Linear GraphQL error");
+  }
+  if (payload.data === undefined) {
+    throw new Error("Linear GraphQL returned no data");
+  }
+  return payload.data;
 }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -32,6 +32,20 @@ async function check(
       failures.push(`label "${label}" does not exist on the Tracker`);
     }
   }
+  if (
+    inspect.selectorState !== undefined &&
+    !(inspect.existingStates ?? []).includes(inspect.selectorState)
+  ) {
+    failures.push(`state "${inspect.selectorState}" does not exist on the Tracker`);
+  }
+  if (
+    inspect.selectorProject !== undefined &&
+    !(inspect.existingProjects ?? []).includes(inspect.selectorProject)
+  ) {
+    failures.push(
+      `project "${inspect.selectorProject}" does not exist on the Tracker`,
+    );
+  }
   if (inspect.repository !== undefined) {
     const remote = await originRepository(cwd);
     if (remote !== normalizeRepository(inspect.repository)) {

--- a/src/tracker-adapter.ts
+++ b/src/tracker-adapter.ts
@@ -5,6 +5,10 @@ const brand = Symbol("TrackerAdapter");
 export type TrackerInspect = {
   readonly existingLabels: readonly string[];
   readonly selectorLabels: readonly string[];
+  readonly existingStates?: readonly string[];
+  readonly selectorState?: string;
+  readonly existingProjects?: readonly string[];
+  readonly selectorProject?: string;
   readonly repository?: string;
   readonly canExpressBlocking: boolean;
 };

--- a/test/linear-contract.test.ts
+++ b/test/linear-contract.test.ts
@@ -1,0 +1,6 @@
+import { linearFromWorld } from "./linear-http-fixture.ts";
+import { trackerAdapterContract } from "./tracker-adapter-contract.ts";
+
+trackerAdapterContract("Linear Tracker Adapter", (world) => {
+  return linearFromWorld(world).adapter;
+});

--- a/test/linear-http-fixture.ts
+++ b/test/linear-http-fixture.ts
@@ -1,0 +1,351 @@
+import { linear, type LinearTrackerOptions } from "../src/mod.ts";
+import type { MemoryTrackerOptions } from "../src/testing/memory-tracker.ts";
+
+export type LinearRecordedRequest = {
+  method: string;
+  url: string;
+  body: string | undefined;
+};
+
+type FixtureState = {
+  id: string;
+  name: string;
+  type: "backlog" | "unstarted" | "started" | "completed" | "canceled";
+};
+
+type FixtureIssue = {
+  identifier: string;
+  title: string;
+  description: string;
+  url: string;
+  labels: string[];
+  blockedBy: string[];
+  parent: string | undefined;
+  project: string | undefined;
+  state: string;
+  branchName: string;
+};
+
+export type LinearWorld = MemoryTrackerOptions & {
+  state?: string;
+  project?: string;
+  existingStates?: string[];
+  existingProjects?: string[];
+  suggestedBranchNames?: Record<string, string>;
+  ticketStates?: Record<string, string>;
+  ticketProjects?: Record<string, string>;
+};
+
+export type LinearHttpFixture = {
+  fetch: typeof fetch;
+  requests: readonly LinearRecordedRequest[];
+};
+
+const todoState: FixtureState = {
+  id: "state-todo",
+  name: "Todo",
+  type: "unstarted",
+};
+const inReviewState: FixtureState = {
+  id: "state-in-review",
+  name: "In Review",
+  type: "started",
+};
+const doneState: FixtureState = {
+  id: "state-done",
+  name: "Done",
+  type: "completed",
+};
+
+export const linearInReviewStateId = inReviewState.id;
+export const linearDoneStateId = doneState.id;
+
+export function linearFromWorld(
+  world: LinearWorld,
+): { adapter: ReturnType<typeof linear>; fixture: LinearHttpFixture } {
+  const fixture = linearHttpFixture(world);
+  const label = world.labels[0];
+  const options: LinearTrackerOptions = {
+    ready: world.ready,
+    state: world.state,
+    label,
+    project: world.project,
+    parent: world.parent,
+    ids: world.ids,
+  };
+  return {
+    fixture,
+    adapter: linear(options, { token: "test-token", fetch: fixture.fetch }),
+  };
+}
+
+export function linearHttpFixture(world: LinearWorld): LinearHttpFixture {
+  const issues: FixtureIssue[] = world.tickets.map((ticket) => ({
+    identifier: ticket.id,
+    title: ticket.title,
+    description: ticket.body,
+    url: ticket.url,
+    labels: [...ticket.labels],
+    blockedBy: [...ticket.blockedBy],
+    parent: ticket.parent,
+    project: world.ticketProjects?.[ticket.id],
+    state: world.ticketStates?.[ticket.id] ?? "Todo",
+    branchName: world.suggestedBranchNames?.[ticket.id] ?? "",
+  }));
+  const existingLabels = world.existingLabels ?? [
+    ...new Set([
+      ...world.labels,
+      ...world.tickets.flatMap((ticket) => ticket.labels),
+    ]),
+  ];
+  const existingStates = world.existingStates ?? [
+    todoState.name,
+    inReviewState.name,
+    doneState.name,
+  ];
+  const existingProjects = world.existingProjects ??
+    (world.project === undefined ? [] : [world.project]);
+  const canExpressBlocking = world.canExpressBlocking ?? true;
+  const requests: LinearRecordedRequest[] = [];
+
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = requestUrl(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    const body = typeof init?.body === "string" ? init.body : undefined;
+    requests.push({ method, url, body });
+
+    const headers = headerMap(init?.headers);
+    if (headers.authorization !== "test-token") {
+      return jsonResponse({ errors: [{ message: "Authentication required" }] }, 401);
+    }
+
+    if (url !== "https://api.linear.app/graphql") {
+      return jsonResponse({ errors: [{ message: "Not Found" }] }, 404);
+    }
+
+    return graphqlResponse(
+      body,
+      issues,
+      existingLabels,
+      existingStates,
+      existingProjects,
+      canExpressBlocking,
+    );
+  };
+
+  return { fetch: fetchImpl, requests };
+}
+
+function requestUrl(input: string | URL | Request): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
+  return input.url;
+}
+
+function headerMap(headers: RequestInit["headers"]): Record<string, string> {
+  const result: Record<string, string> = {};
+  if (headers === undefined) {
+    return result;
+  }
+  if (headers instanceof Headers) {
+    for (const [key, value] of headers.entries()) {
+      result[key.toLowerCase()] = value;
+    }
+    return result;
+  }
+  if (Array.isArray(headers)) {
+    for (const pair of headers) {
+      result[pair[0].toLowerCase()] = pair[1];
+    }
+    return result;
+  }
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === "string") {
+      result[key.toLowerCase()] = value;
+    }
+  }
+  return result;
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function statesFromNames(names: readonly string[]): FixtureState[] {
+  return names.map((name) => {
+    if (name === inReviewState.name) {
+      return inReviewState;
+    }
+    if (name === doneState.name) {
+      return doneState;
+    }
+    if (name === todoState.name) {
+      return todoState;
+    }
+    return { id: `state-${name}`, name, type: "started" };
+  });
+}
+
+function graphqlResponse(
+  body: string | undefined,
+  issues: FixtureIssue[],
+  existingLabels: readonly string[],
+  existingStates: readonly string[],
+  existingProjects: readonly string[],
+  canExpressBlocking: boolean,
+): Response {
+  const parsed = body === undefined
+    ? { operationName: "", variables: {} }
+    : JSON.parse(body) as {
+      operationName?: string;
+      variables?: {
+        id?: string;
+        cursor?: string;
+        input?: { stateId?: string };
+      };
+    };
+  const operation = parsed.operationName ?? "";
+  const variables = parsed.variables ?? {};
+  const states = statesFromNames(existingStates);
+
+  if (operation === "SchemaProbe") {
+    const fields = canExpressBlocking
+      ? [{ name: "inverseRelations" }, { name: "title" }]
+      : [{ name: "title" }];
+    return jsonResponse({ data: { __type: { fields } } }, 200);
+  }
+
+  if (operation === "IssueLabels") {
+    return jsonResponse({
+      data: {
+        issueLabels: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: existingLabels.map((name) => ({ name })),
+        },
+      },
+    }, 200);
+  }
+
+  if (operation === "WorkflowStates") {
+    return jsonResponse({
+      data: {
+        workflowStates: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: states,
+        },
+      },
+    }, 200);
+  }
+
+  if (operation === "Projects") {
+    return jsonResponse({
+      data: {
+        projects: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: existingProjects.map((name) => ({ name })),
+        },
+      },
+    }, 200);
+  }
+
+  if (operation === "Frontier") {
+    const nodes = issues.map((issue) => toFrontierNode(issue, issues));
+    return jsonResponse({
+      data: {
+        issues: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes,
+        },
+      },
+    }, 200);
+  }
+
+  if (operation === "IssueStates") {
+    const issue = issues.find((candidate) => candidate.identifier === variables.id);
+    if (issue === undefined) {
+      return jsonResponse({ data: { issue: null } }, 200);
+    }
+    return jsonResponse({
+      data: {
+        issue: {
+          id: issue.identifier,
+          team: {
+            states: { nodes: states },
+          },
+        },
+      },
+    }, 200);
+  }
+
+  if (operation === "LeaveFrontier") {
+    const issue = issues.find((candidate) => candidate.identifier === variables.id);
+    const stateId = variables.input?.stateId;
+    const next = states.find((state) => state.id === stateId);
+    if (issue !== undefined && next !== undefined) {
+      issue.state = next.name;
+    }
+    return jsonResponse({
+      data: {
+        issueUpdate: {
+          success: true,
+          issue: issue === undefined
+            ? null
+            : {
+              identifier: issue.identifier,
+              state: {
+                name: issue.state,
+                type: states.find((state) => state.name === issue.state)?.type ??
+                  "started",
+              },
+            },
+        },
+      },
+    }, 200);
+  }
+
+  return jsonResponse({
+    errors: [{ message: `Unknown GraphQL operation ${operation}` }],
+  }, 200);
+}
+
+function toFrontierNode(issue: FixtureIssue, issues: FixtureIssue[]) {
+  const state = statesFromNames([issue.state])[0] ?? todoState;
+  return {
+    identifier: issue.identifier,
+    title: issue.title,
+    description: issue.description,
+    url: issue.url,
+    branchName: issue.branchName,
+    state: { id: state.id, name: state.name, type: state.type },
+    labels: { nodes: issue.labels.map((name) => ({ name })) },
+    project: issue.project === undefined ? null : { name: issue.project },
+    parent: issue.parent === undefined ? null : { identifier: issue.parent },
+    inverseRelations: {
+      nodes: issue.blockedBy.map((identifier) => {
+        const blocker = issues.find((candidate) => candidate.identifier === identifier);
+        const blockerState = statesFromNames([blocker?.state ?? "Todo"])[0] ??
+          todoState;
+        return {
+          type: "blocks",
+          issue: {
+            identifier,
+            state: { name: blockerState.name, type: blockerState.type },
+            labels: {
+              nodes: (blocker?.labels ?? []).map((name) => ({ name })),
+            },
+            project: blocker?.project === undefined
+              ? null
+              : { name: blocker.project },
+          },
+        };
+      }),
+    },
+  };
+}

--- a/test/linear-live.test.ts
+++ b/test/linear-live.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { linear } from "../src/mod.ts";
+
+const live = process.env.READYRUN_LINEAR_LIVE === "1";
+
+test("live credentialed Linear inspect is opt-in, not required for CI", {
+  skip: !live,
+}, async () => {
+  const label = process.env.READYRUN_LINEAR_LABEL ?? "ready-for-agent";
+  const adapter = linear({
+    ready: "unblocked",
+    label,
+  });
+  const inspect = await adapter.inspect();
+  assert.deepEqual(inspect.selectorLabels, [label]);
+  assert.ok(
+    inspect.existingLabels.includes(label),
+    "expected the live Linear workspace to have the selector label",
+  );
+  assert.equal(inspect.canExpressBlocking, true);
+});

--- a/test/linear.test.ts
+++ b/test/linear.test.ts
@@ -1,0 +1,370 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { defineConfig, doctor, linear, run, UnknownConfigKeyError } from "../src/mod.ts";
+import { recordingWorker } from "../src/testing/mod.ts";
+import {
+  linearDoneStateId,
+  linearFromWorld,
+  linearHttpFixture,
+  linearInReviewStateId,
+} from "./linear-http-fixture.ts";
+import { ticket } from "./tracker-adapter-contract.ts";
+import { throwawayRepo } from "./throwaway-repo.ts";
+
+const silent = { write(_chunk?: string) { return true; } };
+
+const world = {
+  tickets: [ticket({ id: "52" })],
+  ready: "unblocked" as const,
+  labels: ["ready-for-agent"],
+};
+
+test("success moves the Ticket to In Review and never Done", async () => {
+  const { adapter, fixture } = linearFromWorld(world);
+  const frontier = await adapter.frontier();
+  const finished = frontier[0];
+  assert.ok(finished);
+  await adapter.leaveFrontier(finished);
+
+  const bodies = fixture.requests.map((request) => request.body ?? "").join("\n");
+  assert.match(bodies, new RegExp(linearInReviewStateId));
+  assert.equal(bodies.includes(linearDoneStateId), false);
+  assert.equal(
+    fixture.requests.some((request) =>
+      (request.body ?? "").includes("\"type\":\"completed\"")
+    ),
+    false,
+  );
+});
+
+test("when Linear exposes a suggested branch name, that is the Branch", async () => {
+  const { adapter } = linearFromWorld({
+    ...world,
+    suggestedBranchNames: { "52": "feature/eng-52-ticket-52" },
+  });
+  const [picked] = await adapter.frontier();
+  assert.ok(picked);
+  assert.equal(adapter.branchName(picked), "feature/eng-52-ticket-52");
+});
+
+test("when Linear has no suggested branch name, the Branch is a convention over the identifier", async () => {
+  const { adapter } = linearFromWorld(world);
+  const [picked] = await adapter.frontier();
+  assert.ok(picked);
+  assert.equal(adapter.branchName(picked), "readyrun/52");
+});
+
+test("an unblocked Ticket that does not match the Linear state is not on the Frontier", async () => {
+  const { adapter } = linearFromWorld({
+    tickets: [ticket({ id: "52" }), ticket({ id: "99" })],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+    state: "Todo",
+    ticketStates: { "52": "Todo", "99": "In Progress" },
+    existingStates: ["Todo", "In Progress", "In Review", "Done"],
+  });
+  const frontier = await adapter.frontier();
+  assert.deepEqual(
+    frontier.map((item) => item.id),
+    ["52"],
+  );
+});
+
+test("a Ticket blocked by work that does not match the selector is still blocked", async () => {
+  const { adapter } = linearFromWorld({
+    tickets: [
+      ticket({ id: "52", labels: ["other"] }),
+      ticket({
+        id: "53",
+        labels: ["ready-for-agent"],
+        blockedBy: ["52"],
+      }),
+    ],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+  });
+  const frontier = await adapter.frontier();
+  assert.deepEqual(
+    frontier.map((item) => item.id),
+    [],
+  );
+});
+
+test("an unblocked Ticket that does not match the Linear project is not on the Frontier", async () => {
+  const { adapter } = linearFromWorld({
+    tickets: [ticket({ id: "52" }), ticket({ id: "99" })],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+    project: "Alpha",
+    ticketProjects: { "52": "Alpha", "99": "Beta" },
+    existingProjects: ["Alpha", "Beta"],
+  });
+  const frontier = await adapter.frontier();
+  assert.deepEqual(
+    frontier.map((item) => item.id),
+    ["52"],
+  );
+});
+
+test("Linear Frontier needs a state, label, or project", () => {
+  assert.throws(
+    () => linear({ ready: "unblocked" }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /state, label, or project/);
+      return true;
+    },
+  );
+});
+
+test("unknown keys on the Linear Tracker Adapter factory are an error", () => {
+  const options = {
+    ready: "unblocked" as const,
+    label: "ready-for-agent",
+    team: "ENG",
+  };
+  assert.throws(
+    () => linear(options),
+    (error: unknown) => {
+      assert.ok(error instanceof UnknownConfigKeyError);
+      assert.deepEqual([...error.keys], ["team"]);
+      return true;
+    },
+  );
+});
+
+test("inspect reports labels, states, and projects that exist on Linear, not only the selector", async () => {
+  const { adapter } = linearFromWorld({
+    tickets: [ticket({ id: "52" })],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+    state: "Todo",
+    project: "Alpha",
+    existingLabels: ["ready-for-agent", "bug"],
+    existingStates: ["Todo", "In Review", "Done"],
+    existingProjects: ["Alpha", "Beta"],
+  });
+  const inspect = await adapter.inspect();
+  assert.deepEqual(inspect.existingLabels, ["ready-for-agent", "bug"]);
+  assert.deepEqual(inspect.selectorLabels, ["ready-for-agent"]);
+  assert.deepEqual(inspect.existingStates, ["Todo", "In Review", "Done"]);
+  assert.equal(inspect.selectorState, "Todo");
+  assert.deepEqual(inspect.existingProjects, ["Alpha", "Beta"]);
+  assert.equal(inspect.selectorProject, "Alpha");
+  assert.equal(inspect.canExpressBlocking, true);
+});
+
+test("Doctor fails when a named Linear label does not exist on the Tracker", async () => {
+  const repo = await throwawayRepo();
+  const { adapter } = linearFromWorld({
+    tickets: [ticket({ id: "52" })],
+    ready: "unblocked",
+    labels: ["does-not-exist"],
+    existingLabels: ["ready-for-agent"],
+  });
+  const chunks: string[] = [];
+  try {
+    const exit = await doctor({
+      config: defineConfig({
+        tracker: adapter,
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(exit, 1);
+    assert.match(
+      chunks.join(""),
+      /Doctor: label "does-not-exist" does not exist on the Tracker/,
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("Doctor fails when a named Linear state does not exist on the Tracker", async () => {
+  const repo = await throwawayRepo();
+  const { adapter } = linearFromWorld({
+    tickets: [ticket({ id: "52" })],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+    state: "does-not-exist",
+    existingStates: ["Todo", "In Review"],
+  });
+  const chunks: string[] = [];
+  try {
+    const exit = await doctor({
+      config: defineConfig({
+        tracker: adapter,
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(exit, 1);
+    assert.match(
+      chunks.join(""),
+      /Doctor: state "does-not-exist" does not exist on the Tracker/,
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("Doctor fails when a named Linear project does not exist on the Tracker", async () => {
+  const repo = await throwawayRepo();
+  const { adapter } = linearFromWorld({
+    tickets: [ticket({ id: "52" })],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+    project: "does-not-exist",
+    existingProjects: ["Alpha"],
+  });
+  const chunks: string[] = [];
+  try {
+    const exit = await doctor({
+      config: defineConfig({
+        tracker: adapter,
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(exit, 1);
+    assert.match(
+      chunks.join(""),
+      /Doctor: project "does-not-exist" does not exist on the Tracker/,
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("Doctor fails when Linear cannot express blocking", async () => {
+  const repo = await throwawayRepo();
+  const { adapter } = linearFromWorld({
+    ...world,
+    canExpressBlocking: false,
+  });
+  const chunks: string[] = [];
+  try {
+    const exit = await doctor({
+      config: defineConfig({
+        tracker: adapter,
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(exit, 1);
+    assert.match(
+      chunks.join(""),
+      /Doctor: Tracker cannot express blocking; unblocked ordering is a lie/,
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("ReadyRun authenticates to Linear via LINEAR_API_KEY; the Worker is not given the token", async () => {
+  const repo = await throwawayRepo();
+  const fixture = linearHttpFixture(world);
+  const adapter = linear(
+    {
+      ready: "unblocked",
+      label: "ready-for-agent",
+    },
+    {
+      env: { LINEAR_API_KEY: "test-token" },
+      fetch: fixture.fetch,
+    },
+  );
+  const worker = recordingWorker({ exitCode: 0 });
+  try {
+    const exit = await run({
+      config: defineConfig({
+        tracker: adapter,
+        worker,
+        model: "composer-2",
+      }),
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+    assert.equal(exit, 0);
+    assert.equal(worker.spawns.length, 1);
+    assert.equal(JSON.stringify(worker.spawns[0]).includes("test-token"), false);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("Doctor fails when ReadyRun cannot authenticate to Linear", async () => {
+  const repo = await throwawayRepo();
+  const adapter = linear(
+    {
+      ready: "unblocked",
+      label: "ready-for-agent",
+    },
+    {
+      env: {},
+    },
+  );
+  const chunks: string[] = [];
+  try {
+    const exit = await doctor({
+      config: defineConfig({
+        tracker: adapter,
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(exit, 1);
+    assert.match(
+      chunks.join(""),
+      /Doctor: ReadyRun could not authenticate to Linear/,
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("the Worker prompt names this Ticket as Linear and the Ticket id", async () => {
+  const { adapter } = linearFromWorld(world);
+  const [picked] = await adapter.frontier();
+  assert.ok(picked);
+  assert.match(adapter.promptCopy(picked), /Linear 52/);
+  assert.doesNotMatch(adapter.promptCopy(picked), /GitHub|#52/);
+  assert.match(adapter.promptCopy(picked), /https:\/\/example\.test\/52/);
+});


### PR DESCRIPTION
## Why

A Consumer can already write `linear()` in `defineConfig`, but that factory did not talk to Linear. Without a real Tracker Adapter, Doctor cannot check state, label, or project against the workspace, a Run cannot pick unblocked Tickets, and success cannot move work to In Review so Done still means merged.

## What

`linear()` now evaluates the Frontier on Linear (`ready: "unblocked"` plus state, label, or project, plus optional parent or ids), authenticates as ReadyRun (`LINEAR_API_KEY`), and on success moves the Ticket to In Review, never Done. The Branch is Linear's suggested name when the adapter can read it. Doctor fails on a missing selector, blocking the Tracker cannot express, or auth failure.

## How

The shared Tracker Adapter contract suite runs against an HTTP fixture at the fetch boundary. Live inspect is opt-in (`READYRUN_LINEAR_LIVE=1`), not CI.

Fixes #18


Made with [Cursor](https://cursor.com)