### PR TITLE
#31: Publish 0.1.0 to JSR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: npm install
+      - run: npm run typecheck
+      - run: npm test
+
+  publish:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: npx jsr publish

--- a/README.md
+++ b/README.md
@@ -4,7 +4,19 @@ A TypeScript CLI that walks a tracker **Frontier** and runs one coding **Worker*
 
 This repo is the product. It is not SpeechDeck. SpeechDeck (and later Trackunit) will *depend* on it.
 
-v0 is specced, not implemented. Spec: [`docs/specs/readyrun-v0.md`](./docs/specs/readyrun-v0.md). Language: [`CONTEXT.md`](./CONTEXT.md). Decisions: [`docs/adr/`](./docs/adr/).
+Spec: [`docs/specs/readyrun-v0.md`](./docs/specs/readyrun-v0.md). Language: [`CONTEXT.md`](./CONTEXT.md). Decisions: [`docs/adr/`](./docs/adr/).
+
+Package: `@readyrun/readyrun` on [JSR](https://jsr.io/@readyrun/readyrun), not npmjs.com. A **Consumer** installs with npm/pnpm/yarn through JSR’s compatibility layer, then writes `readyrun.config.ts`.
+
+```sh
+pnpm add jsr:@readyrun/readyrun
+# npm:
+npx jsr add @readyrun/readyrun
+```
+
+```ts
+import { defineConfig, github, cursor } from "@readyrun/readyrun";
+```
 
 ```sh
 readyrun init
@@ -12,4 +24,12 @@ readyrun doctor
 readyrun run --max 5
 ```
 
-Package: JSR, once it exists. Config in the consumer: `readyrun.config.ts`.
+JSR does not put `readyrun` on PATH. Run the `cli` export as a program (do not import it):
+
+```sh
+deno run -A jsr:@readyrun/readyrun/cli init
+deno run -A jsr:@readyrun/readyrun/cli doctor
+deno run -A jsr:@readyrun/readyrun/cli run --max 5
+```
+
+From this repo, `package.json` `bin` maps `readyrun` to `src/cli.ts` (Node 24).

--- a/docs/adr/0020-jsr-only-not-npmjs.md
+++ b/docs/adr/0020-jsr-only-not-npmjs.md
@@ -1,0 +1,3 @@
+# JSR only; not npmjs.com
+
+ReadyRun is published to jsr.io as `@readyrun/readyrun`. It is not published to registry.npmjs.org. A Consumer still installs with npm, pnpm, or yarn through JSR’s npm compatibility layer (`pnpm add jsr:@readyrun/readyrun` or `npx jsr add @readyrun/readyrun`). Dual-publish was rejected for v0: two registries, two auth stories, and the package is already “published (JSR).” The cost is that JSR’s npm-compat tarball strips `bin`, so a JSR install does not put `readyrun` on PATH. The CLI is the `cli` export, run as a program.

--- a/docs/specs/readyrun-v0.md
+++ b/docs/specs/readyrun-v0.md
@@ -1,6 +1,6 @@
 # ReadyRun v0
 
-Vocabulary in this document is the glossary in [`CONTEXT.md`](../../CONTEXT.md). Decisions it rests on are [`docs/adr/`](../adr/) 0001–0019.
+Vocabulary in this document is the glossary in [`CONTEXT.md`](../../CONTEXT.md). Decisions it rests on are [`docs/adr/`](../adr/) 0001–0020.
 
 ## Problem Statement
 
@@ -121,7 +121,7 @@ A Run cannot start without a cap on how many Tickets it may start, so an unatten
 
 ### Shape and distribution
 
-- ReadyRun is its own repo and its own JSR package. It does not live inside a **Consumer**, and SpeechDeck is a consumer of it rather than its home (ADR 0001).
+- ReadyRun is its own repo and its own JSR package. It does not live inside a **Consumer**, and SpeechDeck is a consumer of it rather than its home (ADR 0001). It is not published to npmjs.com; a **Consumer** still installs with npm/pnpm/yarn through JSR’s compatibility layer. The CLI is the `cli` export, run as a program — JSR does not put `readyrun` on PATH (ADR 0020).
 - The public surface is a `defineConfig` function plus adapter factory functions. A **Consumer** selects one **Tracker Adapter** and one **Worker Adapter** by calling the corresponding factory. Unknown keys are rejected rather than ignored (ADR 0009, 0018).
 - Config lives in one `readyrun.config.ts` at the Consumer root, with JS and MJS accepted under the same basename. There is no search across candidate filenames and no generated scripts directory (ADR 0018).
 - The product name is ReadyRun and the binary is `readyrun`. Spur was rejected after a collision check found two existing agent harnesses shipping a `spur` binary (ADR 0015).

--- a/jsr.json
+++ b/jsr.json
@@ -1,8 +1,9 @@
 {
   "name": "@readyrun/readyrun",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "exports": {
-    ".": "./src/mod.ts"
+    ".": "./src/mod.ts",
+    "./cli": "./src/cli.ts"
   },
   "publish": {
     "include": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readyrun/readyrun",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Walk a tracker Frontier and run one coding Worker per Ticket.",
   "license": "MIT",
   "type": "module",
@@ -8,7 +8,8 @@
     "readyrun": "./src/cli.ts"
   },
   "exports": {
-    ".": "./src/mod.ts"
+    ".": "./src/mod.ts",
+    "./cli": "./src/cli.ts"
   },
   "files": [
     "src",

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+test("jsr.json and package.json share name, version, and the cli export", async () => {
+  const jsr = JSON.parse(
+    await readFile(new URL("../jsr.json", import.meta.url), "utf8"),
+  ) as {
+    name: string;
+    version: string;
+    exports: Record<string, string>;
+  };
+  const pkg = JSON.parse(
+    await readFile(new URL("../package.json", import.meta.url), "utf8"),
+  ) as {
+    name: string;
+    version: string;
+    exports: Record<string, string>;
+  };
+  assert.equal(jsr.name, "@readyrun/readyrun");
+  assert.equal(pkg.name, jsr.name);
+  assert.equal(pkg.version, jsr.version);
+  assert.equal(jsr.exports["."], "./src/mod.ts");
+  assert.equal(jsr.exports["./cli"], "./src/cli.ts");
+  assert.equal(pkg.exports["."], jsr.exports["."]);
+  assert.equal(pkg.exports["./cli"], jsr.exports["./cli"]);
+});


### PR DESCRIPTION
## Why

A **Consumer** still cannot depend on ReadyRun. ADR 0001 said the loop ships as a JSR package rather than copied scripts; the README still said "once it exists." SpeechDeck (and later Trackunit) have nothing to pin.

## What

Publish `@readyrun/readyrun@0.1.0` from CI on `main`, and document how a Consumer installs from JSR.

## How

A GitHub Action runs typecheck and tests, then `npx jsr publish` with OIDC. The version in `jsr.json` is the release; already-published versions no-op.

## Workarounds

JSR's npm-compat tarball strips `bin`, so a JSR install does not put `readyrun` on PATH. The CLI is the `cli` export, run as a program (ADR 0020). Dual-publish to npmjs.com was rejected.

Closes #31

Made with [Cursor](https://cursor.com)