### PR TITLE
Install npm deps before jsr publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,6 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-      - run: npm install
-      - run: npm run typecheck
-      - run: npm test
-
-  publish:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: test
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
@@ -33,4 +20,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-      - run: npx jsr publish
+      - run: npm install
+      - run: npm run typecheck
+      - run: npm test
+      # Deno (jsr publish) resolves npm deps from node_modules, not package.json alone.
+      - run: npx jsr publish --dry-run
+      - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: npx jsr publish


### PR DESCRIPTION
## Why

The first publish from `main` failed: `jsr publish` runs Deno, which looks up `@clack/prompts` in `node_modules`. The publish job checked out a clean tree and never ran `npm install`.

## What

Run install, typecheck, test, and `jsr publish` in one job so publish cannot start from an empty `node_modules`. PRs dry-run the publish.

## How

The real `npx jsr publish` still only runs on push to `main`.

Made with [Cursor](https://cursor.com)