### PR TITLE
Start the CLI when invoked through a pnpm symlink

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@readyrun/readyrun",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "exports": {
     ".": "./src/mod.ts",
     "./cli": "./src/cli.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readyrun/readyrun",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@readyrun/readyrun",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readyrun/readyrun",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Walk a tracker Frontier and run one coding Worker per Ticket.",
   "license": "MIT",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { doctor as doctorEntry, type DoctorOptions } from "./doctor.ts";
 import { init as initEntry, type InitAnswers, type InitOptions } from "./init.ts";
 import { run as runEntry, RunCapRequiredError, type RunOptions } from "./run.ts";
@@ -177,7 +177,11 @@ function isCliEntry(): boolean {
   if (argv1 === undefined) {
     return false;
   }
-  return import.meta.url === pathToFileURL(resolve(argv1)).href;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(argv1);
+  } catch {
+    return import.meta.url === pathToFileURL(resolve(argv1)).href;
+  }
 }
 
 if (isCliEntry()) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -268,9 +268,8 @@ test("multiple config files of the same basename are refused", async () => {
   );
 });
 
-test("invoking the readyrun binary with no arguments prints usage", async () => {
-  const bin = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
-  const result = await promisify(execFile)(process.execPath, [bin], {
+async function invokeCli(bin: string): Promise<{ stdout: string; status: number }> {
+  return promisify(execFile)(process.execPath, [bin], {
     encoding: "utf8",
   }).then(
     (ok) => ({ stdout: ok.stdout, status: 0 }),
@@ -279,8 +278,28 @@ test("invoking the readyrun binary with no arguments prints usage", async () => 
       status: error.code ?? 1,
     }),
   );
+}
+
+test("invoking the readyrun binary with no arguments prints usage", async () => {
+  const bin = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
+  const result = await invokeCli(bin);
   assert.equal(result.status, 1);
   assert.match(result.stdout, /Usage: readyrun/);
+});
+
+test("invoking the CLI through a symlink still starts", async () => {
+  await mkdir(tmpRoot, { recursive: true });
+  const dir = await mkdtemp(join(tmpRoot, "bin-link-"));
+  try {
+    const target = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
+    const link = join(dir, "readyrun");
+    await symlink(target, link);
+    const result = await invokeCli(link);
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /Usage: readyrun/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 const initAnswers = {


### PR DESCRIPTION
## Why

A Consumer who runs \`node ./node_modules/@readyrun/readyrun/src/cli.js init\` (JSR does not install a \`readyrun\` bin) gets silence. pnpm links the package through \`.pnpm/\`; \`import.meta.url\` is the realpath and \`argv[1]\` is the symlink, so \`isCliEntry\` said this was not the program.

## What

Compare realpaths. 0.1.1 so the next merge publishes the fix.

Made with [Cursor](https://cursor.com)