### PR TITLE
Bump versions together and preview JSR publish on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,84 @@ jobs:
       - run: npm test
       - run: npx jsr publish --dry-run
 
+  publish-preview:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      headline: ${{ steps.preview.outputs.headline }}
+      ok: ${{ steps.preview.outputs.ok }}
+      detail: ${{ steps.preview.outputs.detail }}
+      markdown: ${{ steps.preview.outputs.markdown }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+      - id: preview
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          git diff --name-only "$BASE_SHA" HEAD > /tmp/changed.txt
+          if ! curl -fsSL https://jsr.io/@readyrun/readyrun/meta.json -o /tmp/jsr-meta.json; then
+            {
+              echo "headline=Could not reach JSR"
+              echo "ok=true"
+              echo "willPublish=false"
+              echo "detail<<EOF"
+              echo "Could not fetch jsr.io metadata; skipping publish preview."
+              echo "EOF"
+              echo "markdown<<EOF"
+              echo "Could not fetch jsr.io metadata; skipping publish preview."
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          node --experimental-strip-types scripts/publish-preview.ts \
+            --jsr jsr.json \
+            --meta /tmp/jsr-meta.json \
+            --changed-files /tmp/changed.txt \
+            --ci
+
+  publish-on-merge:
+    if: github.event_name == 'pull_request'
+    needs: publish-preview
+    name: ${{ needs.publish-preview.outputs.headline }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Comment and fail if merge would skip a needed publish
+        env:
+          DETAIL: ${{ needs.publish-preview.outputs.detail }}
+          OK: ${{ needs.publish-preview.outputs.ok }}
+          MARKDOWN: ${{ needs.publish-preview.outputs.markdown }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "$DETAIL" | tee -a "$GITHUB_STEP_SUMMARY"
+          MARKER="<!-- readyrun-publish-preview -->"
+          {
+            printf '%s\n\n' "$MARKER"
+            printf '%s\n' "$MARKDOWN"
+          } > /tmp/comment.md
+          EXISTING="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | awk 'NR==1')"
+          if [ -n "$EXISTING" ]; then
+            gh api --method PATCH "repos/${REPO}/issues/comments/${EXISTING}" -F body=@/tmp/comment.md
+          else
+            gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" -F body=@/tmp/comment.md
+          fi
+          if [ "$OK" != "true" ]; then
+            echo "::error::${DETAIL}"
+            exit 1
+          fi
+          echo "::notice::${DETAIL}"
+
   publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          node --experimental-strip-types scripts/publish-preview.ts \
+          node scripts/publish-preview.ts \
             --jsr jsr.json \
             --meta /tmp/jsr-meta.json \
             --changed-files /tmp/changed.txt \

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@readyrun/readyrun",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "exports": {
     ".": "./src/mod.ts",
     "./cli": "./src/cli.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readyrun/readyrun",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@readyrun/readyrun",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readyrun/readyrun",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Walk a tracker Frontier and run one coding Worker per Ticket.",
   "license": "MIT",
   "type": "module",
@@ -19,7 +19,8 @@
   "scripts": {
     "test": "node --test --experimental-strip-types test/**/*.test.ts",
     "typecheck": "tsc --noEmit",
-    "readyrun": "node --experimental-strip-types src/cli.ts"
+    "readyrun": "node --experimental-strip-types src/cli.ts",
+    "bump": "node --experimental-strip-types scripts/bump.ts"
   },
   "engines": {
     "node": ">=24"

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "README.md"
   ],
   "scripts": {
-    "test": "node --test --experimental-strip-types test/**/*.test.ts",
+    "test": "node --test test/**/*.test.ts",
     "typecheck": "tsc --noEmit",
-    "readyrun": "node --experimental-strip-types src/cli.ts",
-    "bump": "node --experimental-strip-types scripts/bump.ts"
+    "readyrun": "node src/cli.ts",
+    "bump": "node scripts/bump.ts"
   },
   "engines": {
     "node": ">=24"

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+import { existsSync, realpathSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export const bumpUsage = `Usage: npm run bump -- [patch | minor | major | <x.y.z>]
+
+Updates package.json, package-lock.json, and jsr.json together.
+Does not commit or tag. Default is patch.
+`;
+
+const bumpKinds = ["major", "minor", "patch"] as const;
+export type BumpKind = (typeof bumpKinds)[number];
+
+export class BumpError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BumpError";
+  }
+}
+
+function isBumpKind(spec: string): spec is BumpKind {
+  return (bumpKinds as readonly string[]).includes(spec);
+}
+
+function parseSemver(version: string): [number, number, number] {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (match === null) {
+    throw new BumpError(`Not a semver x.y.z: ${version}`);
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function parseBumpSpec(argv: readonly string[]): string {
+  if (argv.length === 0) {
+    return "patch";
+  }
+  if (argv.length !== 1) {
+    throw new BumpError(bumpUsage.trimEnd());
+  }
+  const [arg] = argv;
+  if (arg === undefined) {
+    throw new BumpError(bumpUsage.trimEnd());
+  }
+  if (arg === "-h" || arg === "--help") {
+    throw new BumpError(bumpUsage.trimEnd());
+  }
+  const spec = arg.startsWith("--") ? arg.slice(2) : arg;
+  if (isBumpKind(spec)) {
+    return spec;
+  }
+  parseSemver(spec);
+  return spec;
+}
+
+export function nextVersion(current: string, spec = "patch"): string {
+  if (isBumpKind(spec)) {
+    const [major, minor, patch] = parseSemver(current);
+    if (spec === "major") {
+      return `${major + 1}.0.0`;
+    }
+    if (spec === "minor") {
+      return `${major}.${minor + 1}.0`;
+    }
+    return `${major}.${minor}.${patch + 1}`;
+  }
+  parseSemver(spec);
+  if (spec === current) {
+    throw new BumpError(`Already at ${current}`);
+  }
+  return spec;
+}
+
+type Versioned = { version: string };
+
+type Lockfile = Versioned & {
+  packages?: { ""?: Versioned };
+};
+
+async function readJson<T>(path: string): Promise<T> {
+  return JSON.parse(await readFile(path, "utf8")) as T;
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export async function bump(
+  root: string,
+  spec = "patch",
+): Promise<{ from: string; to: string }> {
+  const pkgPath = join(root, "package.json");
+  const jsrPath = join(root, "jsr.json");
+  const lockPath = join(root, "package-lock.json");
+  const pkg = await readJson<Versioned>(pkgPath);
+  const jsr = await readJson<Versioned>(jsrPath);
+  if (pkg.version !== jsr.version) {
+    throw new BumpError(
+      `package.json (${pkg.version}) and jsr.json (${jsr.version}) disagree; fix that first.`,
+    );
+  }
+  const from = pkg.version;
+  const to = nextVersion(from, spec);
+  pkg.version = to;
+  jsr.version = to;
+  await writeJson(pkgPath, pkg);
+  await writeJson(jsrPath, jsr);
+  if (existsSync(lockPath)) {
+    const lock = await readJson<Lockfile>(lockPath);
+    lock.version = to;
+    if (lock.packages?.[""] !== undefined) {
+      lock.packages[""].version = to;
+    }
+    await writeJson(lockPath, lock);
+  }
+  return { from, to };
+}
+
+function isCliEntry(): boolean {
+  const argv1 = process.argv[1];
+  if (argv1 === undefined) {
+    return false;
+  }
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(argv1);
+  } catch {
+    return import.meta.url === pathToFileURL(resolve(argv1)).href;
+  }
+}
+
+export async function bumpCli(argv: readonly string[]): Promise<number> {
+  const [arg] = argv;
+  if (arg === "-h" || arg === "--help") {
+    process.stdout.write(bumpUsage);
+    return 0;
+  }
+  try {
+    const spec = parseBumpSpec(argv);
+    const { from, to } = await bump(
+      join(dirname(fileURLToPath(import.meta.url)), ".."),
+      spec,
+    );
+    process.stdout.write(`${from} → ${to}\n`);
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    return 1;
+  }
+}
+
+if (isCliEntry()) {
+  process.exitCode = await bumpCli(process.argv.slice(2));
+}

--- a/scripts/publish-preview.ts
+++ b/scripts/publish-preview.ts
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+import { realpathSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export type JsrPublish = {
+  include: readonly string[];
+  exclude: readonly string[];
+};
+
+export type JsrMeta = {
+  latest?: string;
+  versions?: Record<string, unknown>;
+};
+
+export type PublishPreview = {
+  ok: boolean;
+  willPublish: boolean;
+  headline: string;
+  detail: string;
+  markdown: string;
+};
+
+export function globMatch(pattern: string, file: string): boolean {
+  const normalized = file.replaceAll("\\", "/").replace(/^\.\//, "");
+  let rest = pattern;
+  let source = "^";
+  while (rest.length > 0) {
+    if (rest.startsWith("**/")) {
+      source += "(?:.*/)?";
+      rest = rest.slice(3);
+      continue;
+    }
+    if (rest === "**") {
+      source += ".*";
+      rest = "";
+      continue;
+    }
+    if (rest.startsWith("**")) {
+      source += ".*";
+      rest = rest.slice(2);
+      continue;
+    }
+    if (rest.startsWith("*")) {
+      source += "[^/]*";
+      rest = rest.slice(1);
+      continue;
+    }
+    const ch = rest.at(0);
+    if (ch === undefined) {
+      break;
+    }
+    source += /[.+^${}()|[\]\\]/.test(ch) ? `\\${ch}` : ch;
+    rest = rest.slice(1);
+  }
+  return new RegExp(`${source}$`).test(normalized);
+}
+
+export function isPublishedPath(file: string, publish: JsrPublish): boolean {
+  const normalized = file.replaceAll("\\", "/").replace(/^\.\//, "");
+  const included = publish.include.some((pattern) => globMatch(pattern, normalized));
+  if (!included) {
+    return false;
+  }
+  return !publish.exclude.some((pattern) => globMatch(pattern, normalized));
+}
+
+export function publishedVersions(meta: JsrMeta): string[] {
+  const versions = new Set(Object.keys(meta.versions ?? {}));
+  if (meta.latest !== undefined && meta.latest !== "") {
+    versions.add(meta.latest);
+  }
+  return [...versions];
+}
+
+export function previewPublish(input: {
+  name: string;
+  localVersion: string;
+  publishedVersions: readonly string[];
+  changedFiles: readonly string[];
+  publish: JsrPublish;
+}): PublishPreview {
+  const packageFiles = input.changedFiles.filter((file) =>
+    isPublishedPath(file, input.publish),
+  );
+  const alreadyPublished = input.publishedVersions.includes(input.localVersion);
+  const pkg = `${input.name}@${input.localVersion}`;
+  const fileList = formatFiles(packageFiles);
+
+  if (!alreadyPublished) {
+    const headline = `Will publish ${input.localVersion}`;
+    const detail = `This merge will publish ${pkg} to JSR.`;
+    return {
+      ok: true,
+      willPublish: true,
+      headline,
+      detail,
+      markdown: `**This merge will publish** \`${pkg}\` to JSR.`,
+    };
+  }
+
+  if (packageFiles.length === 0) {
+    const headline = "Will not publish (no package changes)";
+    const detail = `${pkg} is already on JSR, and this PR does not change published files. That is expected.`;
+    return {
+      ok: true,
+      willPublish: false,
+      headline,
+      detail,
+      markdown: `**This merge will not publish.** \`${pkg}\` is already on JSR, and this PR does not change published files. That is expected.`,
+    };
+  }
+
+  const headline = "Will not publish — run npm run bump";
+  const detail = `${pkg} is already on JSR, so merge will skip publishing. Published files changed (${fileList}). Run npm run bump.`;
+  return {
+    ok: false,
+    willPublish: false,
+    headline,
+    detail,
+    markdown: `**This merge will not publish.** \`${pkg}\` is already on JSR, so \`jsr publish\` will skip.
+
+Published files in this PR: ${fileList}.
+
+Run \`npm run bump\` (default patch) so merge actually ships a new version.`,
+  };
+}
+
+function formatFiles(files: readonly string[]): string {
+  if (files.length <= 8) {
+    return files.join(", ");
+  }
+  const shown = files.slice(0, 8).join(", ");
+  return `${shown}, and ${files.length - 8} more`;
+}
+
+function isCliEntry(): boolean {
+  const argv1 = process.argv[1];
+  if (argv1 === undefined) {
+    return false;
+  }
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(argv1);
+  } catch {
+    return import.meta.url === pathToFileURL(resolve(argv1)).href;
+  }
+}
+
+function flag(argv: readonly string[], name: string): string | undefined {
+  const index = argv.indexOf(name);
+  if (index === -1) {
+    return undefined;
+  }
+  return argv[index + 1];
+}
+
+async function writeGithubOutput(result: PublishPreview): Promise<void> {
+  const path = process.env.GITHUB_OUTPUT;
+  if (path === undefined) {
+    return;
+  }
+  const block = [
+    `headline=${result.headline}`,
+    `ok=${result.ok}`,
+    `willPublish=${result.willPublish}`,
+    "detail<<EOF",
+    result.detail,
+    "EOF",
+    "markdown<<EOF",
+    result.markdown,
+    "EOF",
+    "",
+  ].join("\n");
+  await writeFile(path, block, { flag: "a" });
+}
+
+export async function publishPreviewCli(argv: readonly string[]): Promise<number> {
+  const jsrPath = flag(argv, "--jsr") ?? "jsr.json";
+  const metaPath = flag(argv, "--meta");
+  const changedPath = flag(argv, "--changed-files");
+  if (metaPath === undefined || changedPath === undefined) {
+    process.stderr.write(
+      "Usage: node scripts/publish-preview.ts --jsr jsr.json --meta meta.json --changed-files changed.txt [--ci]\n",
+    );
+    return 1;
+  }
+  const jsr = JSON.parse(await readFile(jsrPath, "utf8")) as {
+    name: string;
+    version: string;
+    publish: JsrPublish;
+  };
+  const meta = JSON.parse(await readFile(metaPath, "utf8")) as JsrMeta;
+  const changedFiles = (await readFile(changedPath, "utf8"))
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line !== "");
+  const result = previewPublish({
+    name: jsr.name,
+    localVersion: jsr.version,
+    publishedVersions: publishedVersions(meta),
+    changedFiles,
+    publish: jsr.publish,
+  });
+  await writeGithubOutput(result);
+  process.stdout.write(`${result.markdown}\n`);
+  if (argv.includes("--ci")) {
+    return 0;
+  }
+  return result.ok ? 0 : 1;
+}
+
+if (isCliEntry()) {
+  process.exitCode = await publishPreviewCli(process.argv.slice(2));
+}

--- a/test/bump.test.ts
+++ b/test/bump.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  bump,
+  BumpError,
+  nextVersion,
+  parseBumpSpec,
+} from "../scripts/bump.ts";
+
+const tmpRoot = join(fileURLToPath(new URL(".", import.meta.url)), ".tmp");
+
+test("nextVersion increments patch, minor, and major", () => {
+  assert.equal(nextVersion("0.1.1", "patch"), "0.1.2");
+  assert.equal(nextVersion("0.1.1"), "0.1.2");
+  assert.equal(nextVersion("0.1.1", "minor"), "0.2.0");
+  assert.equal(nextVersion("0.1.1", "major"), "1.0.0");
+  assert.equal(nextVersion("0.1.1", "0.3.0"), "0.3.0");
+});
+
+test("nextVersion refuses the current version and non-semver", () => {
+  assert.throws(() => nextVersion("0.1.1", "0.1.1"), BumpError);
+  assert.throws(() => nextVersion("0.1.1", "1"), BumpError);
+  assert.throws(() => nextVersion("v0.1.1", "patch"), BumpError);
+});
+
+test("parseBumpSpec defaults to patch and accepts flags or an exact version", () => {
+  assert.equal(parseBumpSpec([]), "patch");
+  assert.equal(parseBumpSpec(["minor"]), "minor");
+  assert.equal(parseBumpSpec(["--major"]), "major");
+  assert.equal(parseBumpSpec(["0.2.0"]), "0.2.0");
+  assert.throws(() => parseBumpSpec(["patch", "minor"]), BumpError);
+  assert.throws(() => parseBumpSpec(["--help"]), BumpError);
+});
+
+test("bump writes the same version to package.json, jsr.json, and the lockfile", async () => {
+  await mkdir(tmpRoot, { recursive: true });
+  const root = await mkdtemp(join(tmpRoot, "bump-"));
+  try {
+    await writeFile(
+      join(root, "package.json"),
+      `${JSON.stringify({ name: "@readyrun/readyrun", version: "0.1.1" }, null, 2)}\n`,
+    );
+    await writeFile(
+      join(root, "jsr.json"),
+      `${JSON.stringify({ name: "@readyrun/readyrun", version: "0.1.1" }, null, 2)}\n`,
+    );
+    await writeFile(
+      join(root, "package-lock.json"),
+      `${JSON.stringify({
+        name: "@readyrun/readyrun",
+        version: "0.1.1",
+        lockfileVersion: 3,
+        packages: { "": { name: "@readyrun/readyrun", version: "0.1.1" } },
+      }, null, 2)}\n`,
+    );
+    const result = await bump(root, "patch");
+    assert.deepEqual(result, { from: "0.1.1", to: "0.1.2" });
+    const pkg = JSON.parse(await readFile(join(root, "package.json"), "utf8")) as {
+      version: string;
+    };
+    const jsr = JSON.parse(await readFile(join(root, "jsr.json"), "utf8")) as {
+      version: string;
+    };
+    const lock = JSON.parse(
+      await readFile(join(root, "package-lock.json"), "utf8"),
+    ) as { version: string; packages: { "": { version: string } } };
+    assert.equal(pkg.version, "0.1.2");
+    assert.equal(jsr.version, "0.1.2");
+    assert.equal(lock.version, "0.1.2");
+    assert.equal(lock.packages[""].version, "0.1.2");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("bump refuses when package.json and jsr.json already disagree", async () => {
+  await mkdir(tmpRoot, { recursive: true });
+  const root = await mkdtemp(join(tmpRoot, "bump-"));
+  try {
+    await writeFile(
+      join(root, "package.json"),
+      `${JSON.stringify({ version: "0.1.1" }, null, 2)}\n`,
+    );
+    await writeFile(
+      join(root, "jsr.json"),
+      `${JSON.stringify({ version: "0.1.0" }, null, 2)}\n`,
+    );
+    await assert.rejects(() => bump(root, "patch"), BumpError);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/test/publish-preview.test.ts
+++ b/test/publish-preview.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import {
+  globMatch,
+  isPublishedPath,
+  previewPublish,
+  publishedVersions,
+  type JsrPublish,
+} from "../scripts/publish-preview.ts";
+
+const publish = JSON.parse(
+  await readFile(new URL("../jsr.json", import.meta.url), "utf8"),
+) as { name: string; publish: JsrPublish };
+
+test("jsr.json include/exclude decide which PR files are the published package", () => {
+  assert.equal(isPublishedPath("src/init.ts", publish.publish), true);
+  assert.equal(isPublishedPath("src/adapters/github.ts", publish.publish), true);
+  assert.equal(isPublishedPath("README.md", publish.publish), true);
+  assert.equal(isPublishedPath("LICENSE", publish.publish), true);
+  assert.equal(isPublishedPath("jsr.json", publish.publish), true);
+  assert.equal(isPublishedPath("src/testing/mod.ts", publish.publish), false);
+  assert.equal(isPublishedPath("test/init.test.ts", publish.publish), false);
+  assert.equal(isPublishedPath("docs/adr/0020-jsr-only-not-npmjs.md", publish.publish), false);
+  assert.equal(isPublishedPath(".github/workflows/ci.yml", publish.publish), false);
+});
+
+test("globMatch handles jsr.json include and exclude patterns", () => {
+  assert.equal(globMatch("src/**/*.ts", "src/init.ts"), true);
+  assert.equal(globMatch("src/**/*.ts", "src/adapters/github.ts"), true);
+  assert.equal(globMatch("**/*.test.ts", "test/init.test.ts"), true);
+  assert.equal(globMatch("**/*.test.ts", "foo.test.ts"), true);
+  assert.equal(globMatch("src/testing/**", "src/testing/mod.ts"), true);
+  assert.equal(globMatch("LICENSE", "LICENSE"), true);
+  assert.equal(globMatch("LICENSE", "src/LICENSE"), false);
+});
+
+test("a new version on a package-file PR will publish", () => {
+  const result = previewPublish({
+    name: "@readyrun/readyrun",
+    localVersion: "0.1.2",
+    publishedVersions: ["0.1.0", "0.1.1"],
+    changedFiles: ["src/init.ts", "test/init.test.ts"],
+    publish: publish.publish,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.willPublish, true);
+  assert.equal(result.headline, "Will publish 0.1.2");
+  assert.match(result.markdown, /This merge will publish/);
+});
+
+test("the same version with only test or docs changes will not publish, and that is ok", () => {
+  const result = previewPublish({
+    name: "@readyrun/readyrun",
+    localVersion: "0.1.1",
+    publishedVersions: ["0.1.1"],
+    changedFiles: ["test/init.test.ts", "docs/adr/0021-effort-optional-cli-adapter.md"],
+    publish: publish.publish,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.willPublish, false);
+  assert.equal(result.headline, "Will not publish (no package changes)");
+});
+
+test("the same version with published file changes will not publish, and that is not ok", () => {
+  const result = previewPublish({
+    name: "@readyrun/readyrun",
+    localVersion: "0.1.1",
+    publishedVersions: ["0.1.1"],
+    changedFiles: ["src/init.ts", "README.md"],
+    publish: publish.publish,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.willPublish, false);
+  assert.equal(result.headline, "Will not publish — run npm run bump");
+  assert.match(result.markdown, /npm run bump/);
+  assert.match(result.detail, /src\/init\.ts/);
+});
+
+test("publishedVersions includes latest even if versions is empty", () => {
+  assert.deepEqual(publishedVersions({ latest: "0.1.1" }), ["0.1.1"]);
+  assert.deepEqual(publishedVersions({ versions: { "0.1.0": {}, "0.1.1": {} } }).sort(), [
+    "0.1.0",
+    "0.1.1",
+  ]);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "types": ["node"],
     "noUncheckedIndexedAccess": true
   },
-  "include": ["src", "test"]
+  "include": ["src", "test", "scripts"]
 }


### PR DESCRIPTION
## Why

Merging a package change without bumping `jsr.json` looks like a successful publish job, then JSR skips because that version already exists. The version also lives in two manifests, so bumping one and not the other is easy.

## What

`npm run bump` updates `package.json`, the lockfile, and `jsr.json` together (default patch). PRs get a check named **Will publish x.y.z** or **Will not publish — run npm run bump**, plus a sticky comment. Changing published files without a new version fails the check.

This PR is 0.1.2, so merge will publish Init autofill and Effort.


Made with [Cursor](https://cursor.com)