### PR TITLE
43: Document pnpm/npm/yarn CLI wrapper and Worker Adapter prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,42 @@ defineConfig({
 claude({ extraArgs: ["--verbose"] });
 ```
 
+`cursor()` shells out to `agent`, `claude()` shells out to `claude`; both must already be installed and authenticated before `run` — ReadyRun does not manage CLI auth.
+
 ```sh
 readyrun init
 readyrun doctor
 readyrun run --max 5
 ```
 
-JSR does not put `readyrun` on PATH. Run the `cli` export as a program (do not import it):
+JSR does not put `readyrun` on PATH. Run the `cli` export as a program (Deno):
 
 ```sh
 deno run -A jsr:@readyrun/readyrun/cli init
 deno run -A jsr:@readyrun/readyrun/cli doctor
 deno run -A jsr:@readyrun/readyrun/cli run --max 5
+```
+
+pnpm/npm/yarn: JSR's npm-compat tarball strips `bin`, so `pnpm exec readyrun` and `npx readyrun` fail with no hint at the fix. Import the `cli` export from a two-line wrapper script instead, and call that from a `package.json` script:
+
+```js
+// readyrun-cli.mjs
+import { cli } from "@readyrun/readyrun/cli";
+process.exitCode = await cli({ argv: process.argv.slice(2) });
+```
+
+```json
+{
+  "scripts": {
+    "readyrun": "node readyrun-cli.mjs"
+  }
+}
+```
+
+```sh
+pnpm readyrun init
+pnpm readyrun doctor
+pnpm readyrun run --max 5
 ```
 
 From this repo, `package.json` `bin` maps `readyrun` to `src/cli.ts` (Node 24).


### PR DESCRIPTION
## Why

The README's only CLI invocation is the Deno one-liner. A Node/npm/pnpm/yarn Consumer has no documented path from `pnpm add jsr:@readyrun/readyrun` to a working CLI call, and reaches for `pnpm exec readyrun` or `npx readyrun`, both of which fail with no hint toward the fix (JSR's npm-compat tarball strips `bin`, tracked in #38). Separately, nothing documents that `cursor()`/`claude()` shell out to the `agent`/`claude` binaries, so a missing/unauthenticated CLI reads like a Doctor bug rather than a missing README line.

## What

Adds the pnpm/npm/yarn wrapper-script workaround directly beside the existing Deno invocation, and a one-line callout that `cursor()`/`claude()` require their underlying CLI installed and authenticated before `run`.

## How

Verified the documented wrapper snippet end-to-end (installed the package via `file:`, ran the exact `import { cli } from "@readyrun/readyrun/cli"` snippet) to confirm it actually works, not just reads plausibly.

Fixes #43

Made with [Cursor](https://cursor.com)