### PR TITLE
Echo the Worker's exit code on a hard stop

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -113,7 +113,12 @@ export async function run(options: RunOptions): Promise<number> {
       return hardStop(stdout, "spawn", ticket.id);
     }
     if (result.exitCode !== 0) {
-      return hardStop(stdout, "worker", ticket.id);
+      return hardStop(
+        stdout,
+        "worker",
+        ticket.id,
+        `exit code ${result.exitCode}`,
+      );
     }
     try {
       if (config.leaveFrontier) {

--- a/test/run-hard-stop.test.ts
+++ b/test/run-hard-stop.test.ts
@@ -62,7 +62,7 @@ test("hitting the cap is a clean finish distinguished by exit code 0", async () 
 
 test("a Worker exiting non-zero hard-stops the Run without skip or retry", async () => {
   const repo = await throwawayRepo();
-  const worker = recordingWorker({ exitCode: 1 });
+  const worker = recordingWorker({ exitCode: 42 });
   const tracker = memoryTracker({
     tickets: [ticket({ id: "52" }), ticket({ id: "57" })],
     ready: "unblocked",
@@ -93,7 +93,7 @@ test("a Worker exiting non-zero hard-stops the Run without skip or retry", async
       ["52", "57"],
     );
     const output = chunks.join("");
-    assert.match(output, /Hard stop: Ticket 52 failed at worker/);
+    assert.match(output, /Hard stop: Ticket 52 failed at worker: exit code 42/);
   } finally {
     await repo.cleanup();
   }


### PR DESCRIPTION
## Why

A non-zero Worker exit hard-stops the Run with the generic message `Hard stop: Ticket N failed at worker`, which reads the same whether the binary is missing, unauthenticated, crashed, or deliberately exited with a message. A Consumer gets no real signal to act on.

## What

Include the Worker's actual exit code in the hard-stop message, without changing the Run's own 0/1 exit code contract.

## How

Reuses the existing `detail` parameter on `hardStop` (already used for the `git` stage) to append `: exit code N` to the message. Extended the existing worker hard-stop test to use a distinctive exit code (42) and assert it appears in stdout.

Fixes #44

Made with [Cursor](https://cursor.com)