### PR TITLE
Give a Worktree/Branch collision its own error

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdir } from "node:fs/promises";
+import { access, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { promisify } from "node:util";
 
@@ -9,6 +9,15 @@ export class DefaultBranchError extends Error {
   constructor(branch: string) {
     super(`ReadyRun refuses to start a Worker on the default branch (${branch})`);
     this.name = "DefaultBranchError";
+  }
+}
+
+export class WorktreeExistsError extends Error {
+  constructor(branch: string, worktreePath: string) {
+    super(
+      `ReadyRun already has a Worktree for branch ${branch} at ${worktreePath}`,
+    );
+    this.name = "WorktreeExistsError";
   }
 }
 
@@ -70,6 +79,24 @@ function parseOwnerRepo(url: string): string | undefined {
   return path?.[1];
 }
 
+async function branchExists(cwd: string, branch: string): Promise<boolean> {
+  try {
+    await git(cwd, ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function createTicketWorktree(
   cwd: string,
   branch: string,
@@ -85,6 +112,11 @@ export async function createTicketWorktree(
     "worktrees",
     branch.replaceAll("/", "-"),
   );
+
+  if (await branchExists(cwd, branch) || await pathExists(worktreePath)) {
+    throw new WorktreeExistsError(branch, worktreePath);
+  }
+
   await mkdir(join(cwd, ".readyrun", "worktrees"), { recursive: true });
   await exec("git", ["-C", cwd, "worktree", "add", "-b", branch, worktreePath]);
   return worktreePath;

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -6,7 +6,7 @@ export { init } from "./init.ts";
 export type { InitAnswers, InitOptions } from "./init.ts";
 export { run, RunCapRequiredError } from "./run.ts";
 export type { RunOptions } from "./run.ts";
-export { DefaultBranchError } from "./git.ts";
+export { DefaultBranchError, WorktreeExistsError } from "./git.ts";
 export type { Ticket } from "./ticket.ts";
 export { createTrackerAdapter } from "./tracker-adapter.ts";
 export type { TrackerAdapter, TrackerInspect } from "./tracker-adapter.ts";

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
+import { mkdir } from "node:fs/promises";
 import { test } from "node:test";
 import { promisify } from "node:util";
-import { originRepository } from "../src/git.ts";
+import { createTicketWorktree, originRepository, WorktreeExistsError } from "../src/git.ts";
 import { throwawayRepo } from "./throwaway-repo.ts";
 
 const exec = promisify(execFile);
@@ -45,6 +46,57 @@ test("originRepository is undefined when origin is missing", async () => {
   const repo = await throwawayRepo();
   try {
     assert.equal(await originRepository(repo.cwd), undefined);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("createTicketWorktree checks out the Ticket's Branch in .readyrun/worktrees", async () => {
+  const repo = await throwawayRepo();
+  try {
+    const worktreePath = await createTicketWorktree(repo.cwd, "readyrun/52");
+    assert.equal(
+      worktreePath,
+      `${repo.cwd}/.readyrun/worktrees/readyrun-52`,
+    );
+    const { stdout } = await exec("git", [
+      "-C",
+      worktreePath,
+      "branch",
+      "--show-current",
+    ]);
+    assert.equal(stdout.trim(), "readyrun/52");
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("createTicketWorktree refuses a Branch that already exists, instead of a raw git error", async () => {
+  const repo = await throwawayRepo();
+  try {
+    await exec("git", ["-C", repo.cwd, "branch", "readyrun/52"]);
+    await assert.rejects(
+      createTicketWorktree(repo.cwd, "readyrun/52"),
+      (error: unknown) => {
+        assert.ok(error instanceof WorktreeExistsError);
+        assert.match(error.message, /already has a Worktree for branch readyrun\/52/);
+        return true;
+      },
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("createTicketWorktree refuses a leftover Worktree directory even when the Branch does not exist", async () => {
+  const repo = await throwawayRepo();
+  try {
+    const worktreePath = `${repo.cwd}/.readyrun/worktrees/readyrun-52`;
+    await mkdir(worktreePath, { recursive: true });
+    await assert.rejects(
+      createTicketWorktree(repo.cwd, "readyrun/52"),
+      WorktreeExistsError,
+    );
   } finally {
     await repo.cleanup();
   }


### PR DESCRIPTION
## Why

Worktree lifecycle and cleanup policy (#4) is deliberately parked, but the narrower failure mode it's coupled with wasn't: if a Ticket's Branch or Worktree directory already exists when `createTicketWorktree` runs (a re-run after an interrupted Run, a stale directory, etc.), the Run still hard-stops correctly, but the operator only sees git's raw `fatal:` text instead of a ReadyRun-authored message.

## What

Added `WorktreeExistsError`, checked up front for either the Branch or the target Worktree path, naming both in the message. Same hard-stop behavior as before (still surfaces at the "git" stage per ADR 0013) — this only replaces the leaking git internals with a clear, branded error, following the existing `DefaultBranchError` precedent for foreseeable git failures.

## How

`branchExists` (`git show-ref --verify`) and `pathExists` (`fs.access`) run before `git worktree add`; either one being true throws `WorktreeExistsError`. No change to lifetime, cleanup, reuse, or push behavior — those stay out of scope per #4.

Made with [Cursor](https://cursor.com)