### PR TITLE
#61: Honour a repo-local gh account over ambient GH_TOKEN

### DIFF
--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -15,6 +15,7 @@ const knownGitHubKeys = new Set([
   "labels",
   "parent",
   "ids",
+  "account",
 ]);
 
 export type GitHubTrackerOptions = {
@@ -23,13 +24,15 @@ export type GitHubTrackerOptions = {
   labels: string[];
   parent?: string;
   ids?: string[];
+  account?: string;
 };
 
 export type GitHubRuntime = {
   fetch?: typeof fetch;
   token?: string;
   env?: Record<string, string | undefined>;
-  ghAuthToken?: () => Promise<string | undefined>;
+  cwd?: string;
+  ghAuthToken?: (account?: string) => Promise<string | undefined>;
 };
 
 type PageInfo = {
@@ -121,6 +124,15 @@ export function github(
     if (runtime.token !== undefined && runtime.token.length > 0) {
       return runtime.token;
     }
+    const account = firstNonEmpty(options.account) ??
+      await gitConfigGitHubAccount(runtime);
+    if (account !== undefined) {
+      const fromGh = await (runtime.ghAuthToken ?? ghAuthToken)(account);
+      if (fromGh !== undefined && fromGh.length > 0) {
+        return fromGh;
+      }
+      throw new Error("ReadyRun could not authenticate to GitHub");
+    }
     const env = runtime.env ?? process.env;
     const fromEnv = firstNonEmpty(env.GH_TOKEN, env.GITHUB_TOKEN);
     if (fromEnv !== undefined) {
@@ -138,7 +150,25 @@ export function github(
     query: string,
     variables: Record<string, unknown> = {},
   ): Promise<T> {
-    return githubGraphql<T>(http, await token(), operationName, query, variables);
+    try {
+      return await githubGraphql<T>(
+        http,
+        await token(),
+        operationName,
+        query,
+        variables,
+      );
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        /could not resolve to a repository/i.test(error.message)
+      ) {
+        throw new Error(
+          `this token cannot see GitHub repository ${options.repo}`,
+        );
+      }
+      throw error;
+    }
   }
 
   async function rest(
@@ -368,9 +398,31 @@ async function githubRest(
   }
 }
 
-async function ghAuthToken(): Promise<string | undefined> {
+async function gitConfigGitHubAccount(
+  runtime: GitHubRuntime,
+): Promise<string | undefined> {
   try {
-    const { stdout } = await exec("gh", ["auth", "token"], { encoding: "utf8" });
+    const { stdout } = await exec(
+      "git",
+      ["-C", runtime.cwd ?? process.cwd(), "config", "github.account"],
+      {
+        encoding: "utf8",
+        env: { ...process.env, ...runtime.env },
+      },
+    );
+    const account = stdout.trim();
+    return account.length === 0 ? undefined : account;
+  } catch {
+    return undefined;
+  }
+}
+
+async function ghAuthToken(account?: string): Promise<string | undefined> {
+  try {
+    const args = account === undefined
+      ? ["auth", "token"]
+      : ["auth", "token", "--hostname", "github.com", "--user", account];
+    const { stdout } = await exec("gh", args, { encoding: "utf8" });
     const token = stdout.trim();
     return token.length === 0 ? undefined : token;
   } catch {

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -10,6 +10,10 @@ import { throwawayRepo } from "./throwaway-repo.ts";
 
 const exec = promisify(execFile);
 const silent = { write(_chunk?: string) { return true; } };
+const withoutGitHubAccount = {
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+};
 
 const world = {
   tickets: [ticket({ id: "52" })],
@@ -135,6 +139,72 @@ test("Doctor fails when GitHub cannot express blocking", async () => {
   }
 });
 
+test("an explicit runtime token is used even when an account is configured", async () => {
+  const fixture = githubHttpFixture({ repo: "acme/widgets", ...world });
+  const adapter = github(
+    {
+      repo: "acme/widgets",
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+      account: "personal",
+    },
+    {
+      token: "test-token",
+      env: { GH_TOKEN: "ambient-token" },
+      ghAuthToken: () => Promise.reject(new Error("gh should not be called")),
+      fetch: fixture.fetch,
+    },
+  );
+  const frontier = await adapter.frontier();
+  assert.deepEqual(frontier.map((item) => item.id), ["52"]);
+});
+
+test("github({ account }) uses that user's gh token even when GH_TOKEN is set", async () => {
+  const fixture = githubHttpFixture({ repo: "acme/widgets", ...world });
+  const adapter = github(
+    {
+      repo: "acme/widgets",
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+      account: "personal",
+    },
+    {
+      env: { GH_TOKEN: "ambient-token", GITHUB_TOKEN: "also-ambient" },
+      ghAuthToken: (account) =>
+        Promise.resolve(account === "personal" ? "test-token" : "wrong-token"),
+      fetch: fixture.fetch,
+    },
+  );
+  const frontier = await adapter.frontier();
+  assert.deepEqual(frontier.map((item) => item.id), ["52"]);
+});
+
+test("git config github.account uses that user's gh token even when GH_TOKEN is set", async () => {
+  const repo = await throwawayRepo();
+  const fixture = githubHttpFixture({ repo: "acme/widgets", ...world });
+  try {
+    await exec("git", ["-C", repo.cwd, "config", "github.account", "personal"]);
+    const adapter = github(
+      {
+        repo: "acme/widgets",
+        ready: "unblocked",
+        labels: ["ready-for-agent"],
+      },
+      {
+        env: { GH_TOKEN: "ambient-token" },
+        cwd: repo.cwd,
+        ghAuthToken: (account) =>
+          Promise.resolve(account === "personal" ? "test-token" : "wrong-token"),
+        fetch: fixture.fetch,
+      },
+    );
+    const frontier = await adapter.frontier();
+    assert.deepEqual(frontier.map((item) => item.id), ["52"]);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
 test("ReadyRun authenticates to GitHub via GH_TOKEN; the Worker is not given the token", async () => {
   const repo = await repoWithOrigin();
   const fixture = githubHttpFixture({ repo: "acme/widgets", ...world });
@@ -145,7 +215,8 @@ test("ReadyRun authenticates to GitHub via GH_TOKEN; the Worker is not given the
       labels: ["ready-for-agent"],
     },
     {
-      env: { GH_TOKEN: "test-token" },
+      env: { GH_TOKEN: "test-token", ...withoutGitHubAccount },
+      cwd: repo.cwd,
       ghAuthToken: () => Promise.reject(new Error("gh should not be called")),
       fetch: fixture.fetch,
     },
@@ -171,6 +242,7 @@ test("ReadyRun authenticates to GitHub via GH_TOKEN; the Worker is not given the
 });
 
 test("ReadyRun authenticates to GitHub via gh when no token is in the environment", async () => {
+  const repo = await throwawayRepo();
   const fixture = githubHttpFixture({ repo: "acme/widgets", ...world });
   const adapter = github(
     {
@@ -179,13 +251,19 @@ test("ReadyRun authenticates to GitHub via gh when no token is in the environmen
       labels: ["ready-for-agent"],
     },
     {
-      env: {},
-      ghAuthToken: () => Promise.resolve("test-token"),
+      env: { ...withoutGitHubAccount },
+      cwd: repo.cwd,
+      ghAuthToken: (account) =>
+        Promise.resolve(account === undefined ? "test-token" : "wrong-token"),
       fetch: fixture.fetch,
     },
   );
-  const frontier = await adapter.frontier();
-  assert.deepEqual(frontier.map((item) => item.id), ["52"]);
+  try {
+    const frontier = await adapter.frontier();
+    assert.deepEqual(frontier.map((item) => item.id), ["52"]);
+  } finally {
+    await repo.cleanup();
+  }
 });
 
 test("Doctor fails when ReadyRun cannot authenticate to GitHub", async () => {
@@ -197,7 +275,8 @@ test("Doctor fails when ReadyRun cannot authenticate to GitHub", async () => {
       labels: ["ready-for-agent"],
     },
     {
-      env: {},
+      env: { ...withoutGitHubAccount },
+      cwd: repo.cwd,
       ghAuthToken: () => Promise.resolve(undefined),
     },
   );
@@ -222,6 +301,58 @@ test("Doctor fails when ReadyRun cannot authenticate to GitHub", async () => {
       chunks.join(""),
       /Doctor: ReadyRun could not authenticate to GitHub/,
     );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("Doctor names a token that cannot see the repository, not a wrong repo string", async () => {
+  const repo = await repoWithOrigin();
+  const adapter = github(
+    {
+      repo: "acme/widgets",
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+    },
+    {
+      token: "test-token",
+      fetch: async () =>
+        new Response(
+          JSON.stringify({
+            data: { repository: null },
+            errors: [{
+              message:
+                "Could not resolve to a Repository with the name 'acme/widgets'.",
+            }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    },
+  );
+  const chunks: string[] = [];
+  try {
+    const exit = await doctor({
+      config: defineConfig({
+        tracker: adapter,
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(exit, 1);
+    const output = chunks.join("");
+    assert.match(
+      output,
+      /Doctor: this token cannot see GitHub repository acme\/widgets/,
+    );
+    assert.doesNotMatch(output, /Could not resolve/);
+    assert.doesNotMatch(output, /was not found/);
   } finally {
     await repo.cleanup();
   }


### PR DESCRIPTION
## Why

On a machine with more than one GitHub identity, ReadyRun preferred ambient `GH_TOKEN` over the repo-local `gh` user SpeechDeck pins with `git config github.account`. Doctor and Frontier then sent the work token to GraphQL, got `Could not resolve to a Repository`, and reported that as if `github({ repo })` were a typo. Unsetting `GH_TOKEN` or switching the global `gh` account raced every other checkout.

## What

`github()` asks `gh` for `github({ account })` or `git config github.account` before ambient tokens. Doctor names a token that cannot see the repository instead of relaying the GraphQL string.

Closes #61

Made with [Cursor](https://cursor.com)