### PR TITLE
#64: Make each Ticket Worktree a runnable checkout

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { access, mkdir } from "node:fs/promises";
+import { access, mkdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { promisify } from "node:util";
 
@@ -18,6 +18,18 @@ export class WorktreeExistsError extends Error {
       `ReadyRun already has a Worktree for branch ${branch} at ${worktreePath}`,
     );
     this.name = "WorktreeExistsError";
+  }
+}
+
+export class WorktreeInstallError extends Error {
+  constructor(command: string, output: string) {
+    const detail = output.trim();
+    super(
+      detail === ""
+        ? `ReadyRun failed to install Worktree dependencies with ${command}`
+        : `ReadyRun failed to install Worktree dependencies with ${command}:\n${detail}`,
+    );
+    this.name = "WorktreeInstallError";
   }
 }
 
@@ -119,5 +131,93 @@ export async function createTicketWorktree(
 
   await mkdir(join(cwd, ".readyrun", "worktrees"), { recursive: true });
   await exec("git", ["-C", cwd, "worktree", "add", "-b", branch, worktreePath]);
+  await installWorktreeDependencies(worktreePath);
   return worktreePath;
+}
+
+async function installWorktreeDependencies(worktreePath: string): Promise<void> {
+  const command = await detectInstallCommand(worktreePath);
+  if (command === undefined) {
+    return;
+  }
+  const invocation = [command.bin, ...command.args].join(" ");
+  try {
+    await exec(command.bin, command.args, { cwd: worktreePath, encoding: "utf8" });
+  } catch (error) {
+    throw new WorktreeInstallError(invocation, execErrorOutput(error));
+  }
+}
+
+function execErrorOutput(error: unknown): string {
+  if (error !== null && typeof error === "object") {
+    const stdout = "stdout" in error && typeof error.stdout === "string"
+      ? error.stdout
+      : "";
+    const stderr = "stderr" in error && typeof error.stderr === "string"
+      ? error.stderr
+      : "";
+    const combined = `${stdout}${stderr}`.trim();
+    if (combined !== "") {
+      return combined;
+    }
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+type PackageManager = "pnpm" | "npm" | "yarn";
+
+const installCommands: Record<PackageManager, { bin: string; args: string[] }> = {
+  pnpm: { bin: "pnpm", args: ["install", "--frozen-lockfile"] },
+  npm: { bin: "npm", args: ["ci"] },
+  yarn: { bin: "yarn", args: ["--frozen-lockfile"] },
+};
+
+async function detectInstallCommand(
+  worktreePath: string,
+): Promise<{ bin: string; args: string[] } | undefined> {
+  const packageJsonPath = join(worktreePath, "package.json");
+  if (!await pathExists(packageJsonPath)) {
+    return undefined;
+  }
+  const fromLockfile = await lockfilePackageManager(worktreePath);
+  if (fromLockfile === undefined) {
+    return undefined;
+  }
+  const fromField = await packageManagerField(packageJsonPath);
+  return installCommands[fromField ?? fromLockfile];
+}
+
+async function packageManagerField(
+  packageJsonPath: string,
+): Promise<PackageManager | undefined> {
+  try {
+    const manifest = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
+      packageManager?: unknown;
+    };
+    if (typeof manifest.packageManager !== "string") {
+      return undefined;
+    }
+    const name = manifest.packageManager.split("@")[0];
+    if (name === "pnpm" || name === "npm" || name === "yarn") {
+      return name;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function lockfilePackageManager(
+  worktreePath: string,
+): Promise<PackageManager | undefined> {
+  if (await pathExists(join(worktreePath, "pnpm-lock.yaml"))) {
+    return "pnpm";
+  }
+  if (await pathExists(join(worktreePath, "yarn.lock"))) {
+    return "yarn";
+  }
+  if (await pathExists(join(worktreePath, "package-lock.json"))) {
+    return "npm";
+  }
+  return undefined;
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -6,7 +6,7 @@ export { init } from "./init.ts";
 export type { InitAnswers, InitOptions } from "./init.ts";
 export { run, RunCapRequiredError } from "./run.ts";
 export type { RunOptions } from "./run.ts";
-export { DefaultBranchError, WorktreeExistsError } from "./git.ts";
+export { DefaultBranchError, WorktreeExistsError, WorktreeInstallError } from "./git.ts";
 export type { Ticket } from "./ticket.ts";
 export { createTrackerAdapter } from "./tracker-adapter.ts";
 export type { TrackerAdapter, TrackerInspect } from "./tracker-adapter.ts";

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -1,12 +1,41 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdir } from "node:fs/promises";
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { test } from "node:test";
 import { promisify } from "node:util";
-import { createTicketWorktree, originRepository, WorktreeExistsError } from "../src/git.ts";
-import { throwawayRepo } from "./throwaway-repo.ts";
+import { createTicketWorktree, originRepository, WorktreeExistsError, WorktreeInstallError } from "../src/git.ts";
+import { commitMismatchedNpmLockfile, commitNpmConsumer, commitRepoFiles, throwawayRepo } from "./throwaway-repo.ts";
 
 const exec = promisify(execFile);
+
+async function withInstallShim(
+  cwd: string,
+  bin: string,
+  fn: () => Promise<void>,
+): Promise<string> {
+  const binDir = join(cwd, ".bins");
+  const record = join(cwd, "install-args");
+  await mkdir(binDir, { recursive: true });
+  await writeFile(
+    join(binDir, bin),
+    `#!/bin/sh
+printf '%s\\n' "$*" > "$READYRUN_INSTALL_RECORD"
+mkdir -p node_modules
+`,
+    { mode: 0o755 },
+  );
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${binDir}${previousPath === undefined ? "" : `:${previousPath}`}`;
+  process.env.READYRUN_INSTALL_RECORD = record;
+  try {
+    await fn();
+    return (await readFile(record, "utf8")).trim();
+  } finally {
+    process.env.PATH = previousPath;
+    delete process.env.READYRUN_INSTALL_RECORD;
+  }
+}
 
 test("originRepository is owner/name from an ssh origin, preserving case", async () => {
   const repo = await throwawayRepo();
@@ -80,6 +109,96 @@ test("createTicketWorktree refuses a Branch that already exists, instead of a ra
       (error: unknown) => {
         assert.ok(error instanceof WorktreeExistsError);
         assert.match(error.message, /already has a Worktree for branch readyrun\/52/);
+        return true;
+      },
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("createTicketWorktree installs Worktree deps from a Consumer lockfile before returning", async () => {
+  const repo = await throwawayRepo();
+  try {
+    await commitNpmConsumer(repo.cwd);
+    const worktreePath = await createTicketWorktree(repo.cwd, "readyrun/52");
+    await access(join(worktreePath, "node_modules"));
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("createTicketWorktree runs pnpm install --frozen-lockfile when packageManager names pnpm", async () => {
+  const repo = await throwawayRepo();
+  try {
+    await commitRepoFiles(repo.cwd, {
+      "package.json": `${JSON.stringify({
+        name: "fixture-consumer",
+        version: "1.0.0",
+        packageManager: "pnpm@9.15.0",
+      }, null, 2)}\n`,
+      "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+    });
+    let worktreePath = "";
+    const args = await withInstallShim(repo.cwd, "pnpm", async () => {
+      worktreePath = await createTicketWorktree(repo.cwd, "readyrun/52");
+    });
+    await access(join(worktreePath, "node_modules"));
+    assert.equal(args, "install --frozen-lockfile");
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("createTicketWorktree runs yarn --frozen-lockfile when the Consumer has a yarn.lock", async () => {
+  const repo = await throwawayRepo();
+  try {
+    await commitRepoFiles(repo.cwd, {
+      "package.json": `${JSON.stringify({
+        name: "fixture-consumer",
+        version: "1.0.0",
+      }, null, 2)}\n`,
+      "yarn.lock": "# yarn lockfile v1\n",
+    });
+    let worktreePath = "";
+    const args = await withInstallShim(repo.cwd, "yarn", async () => {
+      worktreePath = await createTicketWorktree(repo.cwd, "readyrun/52");
+    });
+    await access(join(worktreePath, "node_modules"));
+    assert.equal(args, "--frozen-lockfile");
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("createTicketWorktree skips install when the Consumer has no lockfile", async () => {
+  const repo = await throwawayRepo();
+  try {
+    await commitRepoFiles(repo.cwd, {
+      "package.json": `${JSON.stringify({
+        name: "fixture-consumer",
+        version: "1.0.0",
+      }, null, 2)}\n`,
+    });
+    const worktreePath = await createTicketWorktree(repo.cwd, "readyrun/52");
+    await assert.rejects(access(join(worktreePath, "node_modules")), {
+      code: "ENOENT",
+    });
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("createTicketWorktree fails with the install command's output when install fails", async () => {
+  const repo = await throwawayRepo();
+  try {
+    await commitMismatchedNpmLockfile(repo.cwd);
+    await assert.rejects(
+      createTicketWorktree(repo.cwd, "readyrun/52"),
+      (error: unknown) => {
+        assert.ok(error instanceof WorktreeInstallError);
+        assert.match(error.message, /npm ci/);
+        assert.match(error.message, /in sync|lock file/i);
         return true;
       },
     );

--- a/test/run-hard-stop.test.ts
+++ b/test/run-hard-stop.test.ts
@@ -6,7 +6,7 @@ import { createTrackerAdapter, defineConfig, run } from "../src/mod.ts";
 import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
 import { createWorkerAdapter } from "../src/worker-adapter.ts";
 import { ticket } from "./tracker-adapter-contract.ts";
-import { throwawayRepo } from "./throwaway-repo.ts";
+import { commitMismatchedNpmLockfile, throwawayRepo } from "./throwaway-repo.ts";
 
 const exec = promisify(execFile);
 const silent = { write(_chunk?: string) { return true; } };
@@ -166,6 +166,43 @@ test("a git failure creating the Branch or Worktree hard-stops the Run; a Worker
     assert.equal(exitCode, 1);
     assert.equal(worker.spawns.length, 0);
     assert.match(chunks.join(""), /Hard stop: Ticket 52 failed at git/);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a failed Worktree install hard-stops the Run at git with the install output; a Worker never starts", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  const chunks: string[] = [];
+  try {
+    await commitMismatchedNpmLockfile(repo.cwd);
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "52" }), ticket({ id: "57" })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.equal(worker.spawns.length, 0);
+    const output = chunks.join("");
+    assert.match(output, /Hard stop: Ticket 52 failed at git/);
+    assert.match(output, /npm ci/);
+    assert.match(output, /in sync|lock file/i);
   } finally {
     await repo.cleanup();
   }

--- a/test/run-one-ticket.test.ts
+++ b/test/run-one-ticket.test.ts
@@ -1,11 +1,14 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
+import { access } from "node:fs/promises";
+import { join } from "node:path";
 import { test } from "node:test";
 import { promisify } from "node:util";
 import { defineConfig, run } from "../src/mod.ts";
 import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
 import type { Ticket } from "../src/mod.ts";
-import { throwawayRepo } from "./throwaway-repo.ts";
+import { createWorkerAdapter } from "../src/worker-adapter.ts";
+import { commitNpmConsumer, throwawayRepo } from "./throwaway-repo.ts";
 
 const exec = promisify(execFile);
 const silent = { write(_chunk?: string) { return true; } };
@@ -149,6 +152,42 @@ test("the Worker runs in a git Worktree on that Branch, not in the Consumer's pr
     assert.notEqual(spawn.cwd, repo.cwd);
     assert.equal(await git(spawn.cwd, ["rev-parse", "--abbrev-ref", "HEAD"]), "readyrun/52");
     assert.equal(await git(repo.cwd, ["rev-parse", "--abbrev-ref", "HEAD"]), "main");
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("the Worktree has installed deps before the Worker is spawned", async () => {
+  const repo = await throwawayRepo();
+  let nodeModulesAtSpawn = false;
+  const worker = createWorkerAdapter({
+    spawn(request) {
+      return access(join(request.cwd, "node_modules")).then(
+        () => {
+          nodeModulesAtSpawn = true;
+          return { exitCode: 0 };
+        },
+      );
+    },
+  });
+  try {
+    await commitNpmConsumer(repo.cwd);
+    await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(nodeModulesAtSpawn, true);
   } finally {
     await repo.cleanup();
   }

--- a/test/throwaway-repo.ts
+++ b/test/throwaway-repo.ts
@@ -37,3 +37,59 @@ export async function throwawayRepo(options: {
     },
   };
 }
+
+export async function commitRepoFiles(
+  cwd: string,
+  files: Record<string, string>,
+): Promise<void> {
+  for (const [name, contents] of Object.entries(files)) {
+    await mkdir(join(cwd, name, ".."), { recursive: true });
+    await writeFile(join(cwd, name), contents);
+  }
+  await exec("git", ["add", "--", ...Object.keys(files)], { cwd });
+  await exec("git", ["commit", "-m", "consumer manifest"], { cwd });
+}
+
+export async function commitNpmConsumer(cwd: string): Promise<void> {
+  await mkdir(join(cwd, "vendor", "local-dep"), { recursive: true });
+  await writeFile(
+    join(cwd, "vendor", "local-dep", "package.json"),
+    `${JSON.stringify({ name: "local-dep", version: "1.0.0" }, null, 2)}\n`,
+  );
+  await writeFile(
+    join(cwd, "package.json"),
+    `${JSON.stringify({
+      name: "fixture-consumer",
+      version: "1.0.0",
+      dependencies: { "local-dep": "file:vendor/local-dep" },
+    }, null, 2)}\n`,
+  );
+  await exec("npm", ["install", "--package-lock-only"], { cwd });
+  await exec("git", [
+    "add",
+    "package.json",
+    "package-lock.json",
+    "vendor",
+  ], { cwd });
+  await exec("git", ["commit", "-m", "consumer manifest"], { cwd });
+}
+
+export async function commitMismatchedNpmLockfile(cwd: string): Promise<void> {
+  await commitRepoFiles(cwd, {
+    "package.json": `${JSON.stringify({
+      name: "fixture-consumer",
+      version: "1.0.0",
+      dependencies: { "left-pad": "1.3.0" },
+    }, null, 2)}\n`,
+    "package-lock.json": `${JSON.stringify({
+      name: "fixture-consumer",
+      version: "1.0.0",
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        "": { name: "fixture-consumer", version: "1.0.0" },
+      },
+    }, null, 2)}\n`,
+  });
+}
+


### PR DESCRIPTION
## Why

SpeechDeck's Worker on Ticket 52 started in a Worktree with no `node_modules`, tried `pnpm install --frozen-lockfile`, and got auto-blocked because print-mode `ask` cannot surface an approval. That is a harness gap: a Worktree is the Worker's cwd, so it has to be a checkout the Consumer's `pnpm check` / `test` scripts can run.

## What

After `git worktree add`, detect the package manager from `packageManager` or the lockfile and run the matching frozen install in the Worktree before spawn. A failed install hard-stops the Run at git with the command's output. No `package.json` or lockfile skips install.

Closes #64

Made with [Cursor](https://cursor.com)