### PR TITLE
#65: Refuse print-mode ask so a Worker cannot stall

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,7 +59,7 @@ One invocation of the loop, from start until the **Frontier** is empty, the cap 
 _Avoid_: session, job, sprint
 
 **Permissions**:
-How freely a **Worker** may act without asking. `"ask"` or `"unattended"`. Default `"ask"`. Vendor flags (`--yolo`, `--dangerously-skip-permissions`) stay inside the **Worker Adapter**.
+How freely a **Worker** may act without asking. `"ask"` or `"unattended"`. Default `"ask"`. `cursor()` and `claude()` spawn print-mode, so ask is a **Doctor** failure — pass `"unattended"`. Vendor flags (`--yolo`, `--dangerously-skip-permissions`) stay inside the **Worker Adapter**.
 _Avoid_: yolo, autoApprove, boolean `yolo`
 
 **Effort**:
@@ -85,10 +85,10 @@ _Avoid_: max mode (Cursor's interactive slash command), ultracode (a Claude Code
 - **Init** is the only Clack UI, and Clack is its default. `--answers <file>` is the scriptable path through the same writer; it is not a second prompt UI. `run` and `doctor` are flags plus stdout. There is no wizard that assembles a `run` command. Bare `readyrun` is usage, not a menu. An unattended **Run** must not prompt.
 - A **Run** cannot start without a cap: a maximum number of **Tickets** it may start. Hitting the cap stops the **Run**; it does not prompt. A single-**Ticket** invocation is a **Run** with cap 1. There is no unlimited **Run**.
 - A v0 **Run** starts one **Worker** at a time. That is behaviour, not the isolation model: a **Worker** is already one **Ticket**, one **Branch**, one **Worktree**, so concurrency later is a knob, not a rewrite.
-- **Permissions** are first-class on the **Run**: `"ask"` or `"unattended"`. Default `"ask"`. Never implied by looping. The **Worker Adapter** maps `"unattended"` to its flag; `custom` is told the flag. Sandbox-bypass is not a third value in v0.
+- **Permissions** are first-class on the **Run**: `"ask"` or `"unattended"`. Default `"ask"`. Never implied by looping. The **Worker Adapter** maps `"unattended"` to its flag; `custom` is told the flag. `cursor()` and `claude()` spawn print-mode (`-p`); ask has nowhere to go, so **Doctor** (and a **Run**) refuse it and name `--permissions unattended`. Sandbox-bypass is not a third value in v0.
 - **Effort** is first-class on the **Run**: optional config default, CLI `--effort` for this **Run**. The **Worker Adapter** maps it to `--effort`; Cursor does not — pick a model variant instead. **Doctor** fails if effort is set on an adapter that does not map it. Not authored on the **Ticket**.
 - A **Worker**’s model: config default is required (**Doctor** fail if missing). CLI `--model` overrides that default for the **Run**. A label map may override per **Ticket**. The **Ticket** body does not name a model.
-- The **Worker** prompt is owned by the package: loop rules plus **Tracker Adapter** copy (this **Ticket**’s id, title, body, URL). A **Consumer** may append a repo context file from config. That file does not replace tracker instructions. There is no repo `prompt.md` that owns the loop.
+- The **Worker** prompt is owned by the package: loop rules plus **Tracker Adapter** copy (this **Ticket**’s id, title, body, URL). Loop rules tell the **Worker** it will not get a reply and must not ask the **Consumer**; a blocking question is a failed **Ticket**, not a pause. A **Consumer** may append a repo context file from config. That file does not replace tracker instructions. There is no repo `prompt.md` that owns the loop.
 - When a **Worker** succeeds, the **Ticket** must leave the **Frontier**. The **Tracker Adapter** has a default for that (Linear: In Review, not Done; GitHub: drop the frontier label, comment, do not close). A **Consumer** may override; they do not have to write a hook.
 - A **Run** hard-stops (no skip, no retry-forever) on **Tracker** API or auth failure, **Branch**/**Worktree** failure, **Worker** missing or not logged in at spawn, or **Worker** non-zero exit. Empty **Frontier** and cap are clean stops. The harness owns **Tracker** auth; the coding CLI owns its own login.
 
@@ -142,6 +142,9 @@ _Avoid_: max mode (Cursor's interactive slash command), ultracode (a Claude Code
 > **Dev:** "It's a looping **Run**, so that's yolo, right?"
 > **Domain expert:** "No. Looping is not **Permissions**. Default is ask. Pass `"unattended"` if you mean it. We don't say yolo."
 >
+> **Dev:** "cursor() defaults to ask, so the **Worker** will prompt me, right?"
+> **Domain expert:** "No. `cursor()` and `claude()` spawn print-mode (`-p`). That is not a chat. **Doctor** fails unless you pass `"unattended"`."
+>
 > **Dev:** "Do I put `opus` on the GitHub issue?"
 > **Domain expert:** "No. Default is in config. `--model` for this **Run**. A label map if this **Ticket**'s labels say so."
 >
@@ -163,7 +166,7 @@ _Avoid_: max mode (Cursor's interactive slash command), ultracode (a Claude Code
 - **How a Ticket lands** — unresolved. Push-for-review vs stay local, auto-review, integrate later are Policy, not the definition of **Branch**.
 - **Run stats** — unresolved. Token usage, context-window % across **Workers**, printed at the end of a **Run**. Wanted; not v0-blocking.
 - **Automatic review** — resolved for v0: no. A review **Ticket** on the **Frontier** is just a **Ticket**. A second **Worker** that reviews the first is later.
-- **Permissions** — resolved: `"ask"` | `"unattended"`. Default ask. Not yolo. Not a boolean.
+- **Permissions** — resolved: `"ask"` | `"unattended"`. Default ask. Not yolo. Not a boolean. Print-mode (`cursor()`, `claude()`) cannot use ask.
 - **Effort** — resolved: optional config default; CLI overrides the **Run**. Adapter maps to `--effort`. Cursor does not map the flag (model variants). **Doctor** fails that pairing. Not ultracode, not max-mode.
 - **Model** — resolved: required config default; CLI overrides the **Run**; label map overrides per **Ticket**. Not authored on the **Ticket**.
 - **Hard stop** — resolved: **Tracker**/git/**Worker** failure ends the **Run**. No skip, no retry-forever. Cap and empty **Frontier** are clean stops. Harness owns **Tracker** auth; CLI owns Worker login.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ claude({ extraArgs: ["--verbose"] });
 
 `cursor()` shells out to `agent`, `claude()` shells out to `claude`; both must already be installed and authenticated before `run` — ReadyRun does not manage CLI auth.
 
+Both spawn print-mode (`-p`). `permissions: "ask"` (the default) is a Doctor failure — print-mode is not a chat. Pass `--permissions unattended`, or set `permissions: "unattended"` in config. `custom()` does not force print-mode, so ask remains valid there.
+
 `readyrun doctor` can tell "not installed" from "installed but not logged in": `cursor()` and `claude()` each define a cheap probe (`agent status`, `claude auth status`) that Doctor runs once it has confirmed the binary exists, reporting a probe failure distinctly from a missing binary. `custom()` Worker Adapters have no probe and keep today's existence-only check.
 
 For a Tracker this package doesn't ship (Jira, GitLab, ...), build one with `createTrackerAdapter`, the same building block `github()` and `linear()` use internally:

--- a/docs/adr/0027-print-mode-refuses-ask.md
+++ b/docs/adr/0027-print-mode-refuses-ask.md
@@ -1,0 +1,3 @@
+# Print-mode spawn cannot use permissions ask
+
+`cursor()` and `claude()` always spawn `-p`. Ask has nowhere to go: a sandbox approval never reaches the Consumer, and a Worker question is a pause with no reply. Doctor and Run start fail unless permissions is unattended, and the failure names `--permissions unattended`. Relaying a vanished approval as Worker stdout was rejected — that is not ask. Checking TTY alone was rejected: print-mode is the trap even on a TTY, because `-p` is not a chat. `custom()` is unchanged; it does not force print-mode, so ask remains the absence of its unattended flag. The Worker prompt states the same contract: you will not get a reply; do not ask the Consumer; a blocking question is a failed Ticket, not a pause.

--- a/docs/specs/readyrun-v0.md
+++ b/docs/specs/readyrun-v0.md
@@ -80,6 +80,7 @@ A Run cannot start without a cap on how many Tickets it may start, so an unatten
 40. As a repo maintainer, I want the **Worker** to be told this **Ticket**'s identifier, title, body and URL, so that it can read the full issue itself.
 41. As a repo maintainer, I want my optional repo context appended rather than substituted, so that local facts are added without losing the loop's own rules.
 42. As a repo maintainer, I want the **Worker** told never to invent a tracker or fabricate ticket state, so that a failed lookup surfaces instead of being imagined.
+42a. As a repo maintainer, I want the **Worker** told it will not get a reply, so that a blocking question is a failed **Ticket** rather than a pause.
 43. As a repo maintainer, I want the instructions to reflect the adapters I selected, so that a Linear repo is never told about issue numbers.
 
 ### Models and permissions
@@ -92,6 +93,7 @@ A Run cannot start without a cap on how many Tickets it may start, so an unatten
 47b. As an operator, I want a command-line effort override for one **Run**, so that I can try a cheaper or deeper pass without editing config.
 47c. As a repo maintainer on Cursor, I want effort to stay a model variant rather than a flag the **Worker** would reject.
 48. As an operator, I want **Permissions** to be a named choice between asking and unattended, so that the setting reads as intent rather than as a vendor flag.
+48a. As an operator, I want **Doctor** to refuse print-mode spawn with ask, so that I find out before a **Worker** blocks on a question I will never see.
 49. As an operator, I want asking to be the default, so that the first time I run ReadyRun I see what it wants to do.
 50. As an operator, I want looping never to imply unattended, so that a long **Run** does not silently grant the **Worker** free rein.
 51. As an operator, I want each **Worker Adapter** to know its own auto-approve flag, so that unattended means the same thing whichever coding CLI I picked.
@@ -163,7 +165,7 @@ A Run cannot start without a cap on how many Tickets it may start, so an unatten
 
 ### Permissions and models
 
-- **Permissions** is a Run-level value of `ask` or `unattended`, defaulting to `ask`. Looping never implies unattended. Each Worker Adapter maps `unattended` onto its own auto-approve flag; the custom adapter is told which flag to use. Sandbox bypass is not a third value in v0 (ADR 0011).
+- **Permissions** is a Run-level value of `ask` or `unattended`, defaulting to `ask`. Looping never implies unattended. Each Worker Adapter maps `unattended` onto its own auto-approve flag; the custom adapter is told which flag to use. `cursor()` and `claude()` always spawn `-p`; ask has nowhere to go, so Doctor (and a Run) refuse that pairing and name `--permissions unattended`. `custom()` does not force print-mode, so ask remains valid there. Sandbox bypass is not a third value in v0 (ADR 0011, ADR 0027).
 - Model resolution is: a required config default, overridden by a command-line model for the whole Run, overridden by a by-label map for an individual Ticket. Doctor fails when the default is missing. The Ticket body never names a model (ADR 0012).
 - **Effort** is an optional config default (`low` | `medium` | `high` | `xhigh` | `max`), overridden by `--effort` for the Run. The Worker Adapter maps it onto `--effort`. Cursor does not take that flag; Doctor fails if effort is set on an adapter that does not map it (ADR 0021).
 - `cursor()` and `claude()` accept an optional `extraArgs: string[]`, landing between `-p` and `--model` — the same position `custom()`'s own `args` already occupy relative to `--model`. `custom()`'s `args` behaviour is unchanged (ADR 0022).
@@ -173,6 +175,7 @@ A Run cannot start without a cap on how many Tickets it may start, so an unatten
 - Loop rules and tracker-specific instructions ship in the package and are populated by the selected Tracker Adapter with the Ticket's identifier, title, body and URL (ADR 0014).
 - A Consumer may name a repo context file whose contents are appended. It cannot replace the loop or tracker instructions — that was the Ralph prompt file this product exists to remove.
 - The instructions include hard stops: do not invent a tracker, do not fabricate Ticket state, and do not retry a failed tracker call in a loop.
+- The instructions also tell the Worker it will not get a reply and must not ask the Consumer; a blocking question is a failed Ticket, not a pause (ADR 0027).
 
 ### Finishing and failing
 
@@ -182,7 +185,7 @@ A Run cannot start without a cap on how many Tickets it may start, so an unatten
 
 ### Doctor and Init
 
-- Doctor and the start of a Run share one check. Anything that makes the Frontier a lie is fatal: unknown keys, a missing label, a configured repository that is not the git remote, unblocked ordering the Tracker cannot express, a missing Worker binary, a missing model default, effort set on an adapter that does not map it. Unused routing warns. The check runs once at start rather than per iteration (ADR 0009).
+- Doctor and the start of a Run share one check. Anything that makes the Frontier a lie is fatal: unknown keys, a missing label, a configured repository that is not the git remote, unblocked ordering the Tracker cannot express, a missing Worker binary, a missing model default, effort set on an adapter that does not map it, print-mode spawn with permissions ask. Unused routing warns. The check runs once at start rather than per iteration (ADR 0009, ADR 0027).
 - A Worker Adapter may optionally define a cheap probe. When the binary exists and a probe is defined, Doctor runs it and reports a failure distinct from "binary missing" — `cursor()` runs `agent status`, `claude()` runs `claude auth status`. An adapter with no probe (`custom()` today) keeps the existence-only check (ADR 0023).
 - Doctor also reports the Ticket that would be picked next.
 - Init is the single interactive surface: it asks for tracker, worker and frontier selector, then writes the config stub (ADR 0019).

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -3,7 +3,7 @@ import { delimiter, isAbsolute, join } from "node:path";
 import { defineConfig, type ReadyRunConfig } from "./config.ts";
 import { originRepository, normalizeRepository } from "./git.ts";
 import type { Ticket } from "./ticket.ts";
-import type { Effort } from "./worker-adapter.ts";
+import type { Effort, Permissions } from "./worker-adapter.ts";
 
 type DoctorStdout = { write(chunk: string): unknown };
 
@@ -17,6 +17,7 @@ async function check(
   config: ReadyRunConfig,
   cwd: string,
   effort: Effort | undefined,
+  permissions: Permissions,
 ): Promise<string[]> {
   const failures: string[] = [];
   if (typeof config.model !== "string" || config.model.length === 0) {
@@ -75,6 +76,11 @@ async function check(
   if (effort !== undefined && config.worker.effortFlag === undefined) {
     failures.push("effort is set but this Worker Adapter does not map it");
   }
+  if (config.worker.printMode === true && permissions === "ask") {
+    failures.push(
+      "print-mode spawn cannot use permissions ask; pass --permissions unattended",
+    );
+  }
   return failures;
 }
 
@@ -109,8 +115,9 @@ export async function doctorCheck(
   cwd: string,
   stdout: DoctorStdout,
   effort: Effort | undefined = config.effort,
+  permissions: Permissions = config.permissions ?? "ask",
 ): Promise<0 | 1> {
-  const failures = await check(config, cwd, effort);
+  const failures = await check(config, cwd, effort, permissions);
   if (failures.length === 0) {
     return 0;
   }

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,5 +1,7 @@
 const LOOP_RULES = `You are implementing exactly one Ticket. Do not start neighbouring work.
 
+You will not get a reply. Do not ask the Consumer. Decide from the Ticket, the context file, and the repo (CONTEXT.md, docs/adr/). A blocking question is a failed Ticket, not a pause.
+
 Do not invent a Tracker.
 Do not fabricate Ticket state.
 Do not retry a failed Tracker call in a loop.`;

--- a/src/run.ts
+++ b/src/run.ts
@@ -60,7 +60,15 @@ export async function run(options: RunOptions): Promise<number> {
 
   const cwd = options.cwd ?? process.cwd();
   const stdout = options.stdout ?? process.stdout;
-  if (await doctorCheck(config, cwd, stdout, options.effort ?? config.effort) === 1) {
+  if (
+    await doctorCheck(
+      config,
+      cwd,
+      stdout,
+      options.effort ?? config.effort,
+      options.permissions ?? config.permissions,
+    ) === 1
+  ) {
     return 1;
   }
   const context = config.contextFile === undefined

--- a/src/worker-adapter.ts
+++ b/src/worker-adapter.ts
@@ -28,12 +28,13 @@ export type WorkerAdapter = {
   readonly [brand]: true;
   readonly bin?: string;
   readonly effortFlag?: string;
+  readonly printMode?: true;
   readonly probe?: () => Promise<ProbeResult>;
   spawn(request: SpawnRequest): Promise<{ exitCode: number }>;
 };
 
 export function createWorkerAdapter(
-  methods: Partial<Pick<WorkerAdapter, "spawn" | "bin" | "effortFlag" | "probe">> = {},
+  methods: Partial<Pick<WorkerAdapter, "spawn" | "bin" | "effortFlag" | "printMode" | "probe">> = {},
 ): WorkerAdapter {
   return {
     [brand]: true,
@@ -104,6 +105,7 @@ export function printModeWorker(
   return createWorkerAdapter({
     bin,
     effortFlag,
+    printMode: true,
     probe: probeArgs === undefined ? undefined : () => execProbe(bin, probeArgs),
     spawn(request: SpawnRequest) {
       const args = ["-p", ...(extraArgs ?? []), "--model", request.model];

--- a/test/run-spawn-payload.test.ts
+++ b/test/run-spawn-payload.test.ts
@@ -440,6 +440,35 @@ test("the Worker prompt tells the Worker not to invent a Tracker, fabricate Tick
   }
 });
 
+test("the Worker prompt tells the Worker it will not get a reply and must not ask the Consumer", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  try {
+    await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    const prompt = worker.spawns[0]?.prompt;
+    assert.ok(prompt);
+    assert.match(prompt, /You will not get a reply/);
+    assert.match(prompt, /Do not ask the Consumer/);
+    assert.match(prompt, /A blocking question is a failed Ticket, not a pause/);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
 test("Tracker-specific wording in the Worker prompt comes from the selected Tracker Adapter", async () => {
   const repo = await throwawayRepo();
   const worker = recordingWorker({ exitCode: 0 });

--- a/test/worker-adapters.test.ts
+++ b/test/worker-adapters.test.ts
@@ -195,7 +195,7 @@ describe("Worker Adapters", { concurrency: false }, () => {
 
   test("a Cursor Worker Adapter Run spawns the Worker with the prompt, model, Worktree cwd, and Cursor's unattended flag", async () => {
     await withRecordingPath(["agent"], async ({ receiptPath }) => {
-      const unattendedRepo = await throwawayRepo();
+      const repo = await throwawayRepo();
       try {
         await run({
           config: defineConfig({
@@ -209,7 +209,7 @@ describe("Worker Adapters", { concurrency: false }, () => {
             permissions: "unattended",
           }),
           cap: 1,
-          cwd: unattendedRepo.cwd,
+          cwd: repo.cwd,
           stdout: silent,
         });
 
@@ -220,41 +220,17 @@ describe("Worker Adapters", { concurrency: false }, () => {
         assert.equal(unattended.argv[2], "composer-2");
         assert.ok(unattended.argv.includes("--yolo"));
         assert.match(unattended.argv.at(-1) ?? "", /52/);
-        assert.notEqual(unattended.cwd, unattendedRepo.cwd);
+        assert.notEqual(unattended.cwd, repo.cwd);
         assert.match(unattended.cwd, /worktrees/);
       } finally {
-        await unattendedRepo.cleanup();
-      }
-
-      const askRepo = await throwawayRepo();
-      try {
-        await run({
-          config: defineConfig({
-            tracker: memoryTracker({
-              tickets: [ticket({ id: "52" })],
-              ready: "unblocked",
-              labels: ["ready-for-agent"],
-            }),
-            worker: cursor(),
-            model: "composer-2",
-          }),
-          cap: 1,
-          cwd: askRepo.cwd,
-          stdout: silent,
-        });
-
-        const ask = await readReceipt(receiptPath);
-        assert.ok(!ask.argv.includes("--yolo"));
-        assert.ok(!ask.argv.includes("login"));
-      } finally {
-        await askRepo.cleanup();
+        await repo.cleanup();
       }
     });
   });
 
   test("a Claude Worker Adapter Run spawns the Worker with the prompt, model, Worktree cwd, and Claude's unattended flag", async () => {
     await withRecordingPath(["claude"], async ({ receiptPath }) => {
-      const unattendedRepo = await throwawayRepo();
+      const repo = await throwawayRepo();
       try {
         await run({
           config: defineConfig({
@@ -268,7 +244,7 @@ describe("Worker Adapters", { concurrency: false }, () => {
             permissions: "unattended",
           }),
           cap: 1,
-          cwd: unattendedRepo.cwd,
+          cwd: repo.cwd,
           stdout: silent,
         });
 
@@ -279,34 +255,10 @@ describe("Worker Adapters", { concurrency: false }, () => {
         assert.equal(unattended.argv[2], "opus");
         assert.ok(unattended.argv.includes("--dangerously-skip-permissions"));
         assert.match(unattended.argv.at(-1) ?? "", /52/);
-        assert.notEqual(unattended.cwd, unattendedRepo.cwd);
+        assert.notEqual(unattended.cwd, repo.cwd);
         assert.match(unattended.cwd, /worktrees/);
       } finally {
-        await unattendedRepo.cleanup();
-      }
-
-      const askRepo = await throwawayRepo();
-      try {
-        await run({
-          config: defineConfig({
-            tracker: memoryTracker({
-              tickets: [ticket({ id: "52" })],
-              ready: "unblocked",
-              labels: ["ready-for-agent"],
-            }),
-            worker: claude(),
-            model: "opus",
-          }),
-          cap: 1,
-          cwd: askRepo.cwd,
-          stdout: silent,
-        });
-
-        const ask = await readReceipt(receiptPath);
-        assert.ok(!ask.argv.includes("--dangerously-skip-permissions"));
-        assert.ok(!ask.argv.includes("login"));
-      } finally {
-        await askRepo.cleanup();
+        await repo.cleanup();
       }
     });
   });
@@ -325,6 +277,7 @@ describe("Worker Adapters", { concurrency: false }, () => {
             worker: claude(),
             model: "opus",
             effort: "high",
+            permissions: "unattended",
           }),
           cap: 1,
           cwd: withEffort.cwd,
@@ -353,6 +306,7 @@ describe("Worker Adapters", { concurrency: false }, () => {
             }),
             worker: claude(),
             model: "opus",
+            permissions: "unattended",
           }),
           cap: 1,
           cwd: withoutEffort.cwd,
@@ -380,6 +334,7 @@ describe("Worker Adapters", { concurrency: false }, () => {
         worker: cursor(),
         model: "composer-2.5-fast",
         effort: "high",
+        permissions: "unattended",
       });
       try {
         const doctorExit = await doctor({
@@ -412,6 +367,84 @@ describe("Worker Adapters", { concurrency: false }, () => {
         );
         const receipt = await readReceipt(receiptPath);
         assert.deepEqual(receipt.argv, ["status"]);
+      } finally {
+        await repo.cleanup();
+      }
+    });
+  });
+
+  test("print-mode spawn with ask permissions fails Doctor and a Run will not start", async () => {
+    const askPrintMode = /Doctor: .*--permissions unattended/;
+    for (const { bin, worker, model, probeArgv } of [
+      { bin: "agent", worker: cursor(), model: "composer-2", probeArgv: ["status"] },
+      { bin: "claude", worker: claude(), model: "opus", probeArgv: ["auth", "status"] },
+    ]) {
+      await withRecordingPath([bin], async ({ receiptPath }) => {
+        const repo = await throwawayRepo();
+        const doctorChunks: string[] = [];
+        const runChunks: string[] = [];
+        const config = defineConfig({
+          tracker: memoryTracker({
+            tickets: [ticket({ id: "52" })],
+            ready: "unblocked",
+            labels: ["ready-for-agent"],
+          }),
+          worker,
+          model,
+        });
+        const stdout = (chunks: string[]) => ({
+          write(chunk: string) {
+            chunks.push(chunk);
+            return true;
+          },
+        });
+        try {
+          const doctorExit = await doctor({
+            config,
+            cwd: repo.cwd,
+            stdout: stdout(doctorChunks),
+          });
+          const runExit = await run({
+            config,
+            cap: 1,
+            cwd: repo.cwd,
+            stdout: stdout(runChunks),
+          });
+          assert.equal(doctorExit, 1);
+          assert.equal(runExit, 1);
+          assert.equal(doctorChunks.join(""), runChunks.join(""));
+          assert.match(doctorChunks.join(""), askPrintMode);
+          const receipt = await readReceipt(receiptPath);
+          assert.deepEqual(receipt.argv, probeArgv);
+        } finally {
+          await repo.cleanup();
+        }
+      });
+    }
+  });
+
+  test("a Run-level unattended override lets print-mode spawn with the Worker Adapter's unattended flag", async () => {
+    await withRecordingPath(["claude"], async ({ receiptPath }) => {
+      const repo = await throwawayRepo();
+      try {
+        await run({
+          config: defineConfig({
+            tracker: memoryTracker({
+              tickets: [ticket({ id: "52" })],
+              ready: "unblocked",
+              labels: ["ready-for-agent"],
+            }),
+            worker: claude(),
+            model: "opus",
+          }),
+          cap: 1,
+          cwd: repo.cwd,
+          stdout: silent,
+          permissions: "unattended",
+        });
+        const receipt = await readReceipt(receiptPath);
+        assert.equal(receipt.argv[0], "-p");
+        assert.ok(receipt.argv.includes("--dangerously-skip-permissions"));
       } finally {
         await repo.cleanup();
       }
@@ -538,6 +571,7 @@ describe("Worker Adapters", { concurrency: false }, () => {
             }),
             worker: cursor({ extraArgs: ["--reasoning-effort", "high"] }),
             model: "composer-2",
+            permissions: "unattended",
           }),
           cap: 1,
           cwd: repo.cwd,
@@ -571,6 +605,7 @@ describe("Worker Adapters", { concurrency: false }, () => {
             }),
             worker: claude({ extraArgs: ["--verbose"] }),
             model: "opus",
+            permissions: "unattended",
           }),
           cap: 1,
           cwd: repo.cwd,
@@ -603,6 +638,7 @@ describe("Worker Adapters", { concurrency: false }, () => {
             }),
             worker: cursor(),
             model: "composer-2",
+            permissions: "unattended",
           }),
           cwd: repo.cwd,
           stdout: silent,
@@ -706,6 +742,7 @@ describe("Worker Adapters", { concurrency: false }, () => {
             }),
             worker: claude(),
             model: "opus",
+            permissions: "unattended",
           }),
           cwd: repo.cwd,
           stdout: silent,


### PR DESCRIPTION
## Why

SpeechDeck ran `claude()` in print mode with the default `permissions: "ask"`. Claude then hit a sandbox approval that never reached the Consumer, and stopped to ask scope questions the Ticket and ADRs already answered. A Run is not a chat: `-p` means those prompts have nowhere to go.

## What

Doctor and Run refuse print-mode spawn with ask, and name `--permissions unattended`. LOOP_RULES tell the Worker it will not get a reply; a blocking question is a failed Ticket.

Closes #65

Made with [Cursor](https://cursor.com)