### PR TITLE
#72: Cut a Ticket's Branch from an explicit base commit

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -109,9 +109,14 @@ async function pathExists(path: string): Promise<boolean> {
   }
 }
 
+export async function headCommit(cwd: string): Promise<string> {
+  return await git(cwd, ["rev-parse", "HEAD"]);
+}
+
 export async function createTicketWorktree(
   cwd: string,
   branch: string,
+  base: string,
 ): Promise<string> {
   const currentDefault = await defaultBranch(cwd);
   if (branch === currentDefault) {
@@ -130,7 +135,19 @@ export async function createTicketWorktree(
   }
 
   await mkdir(join(cwd, ".readyrun", "worktrees"), { recursive: true });
-  await exec("git", ["-C", cwd, "worktree", "add", "-b", branch, worktreePath]);
+  // A Worktree kept on failure and then deleted by hand rather than with
+  // `git worktree remove` leaves admin state that fails the next add.
+  await git(cwd, ["worktree", "prune"]);
+  await exec("git", [
+    "-C",
+    cwd,
+    "worktree",
+    "add",
+    "-b",
+    branch,
+    worktreePath,
+    base,
+  ]);
   await installWorktreeDependencies(worktreePath);
   return worktreePath;
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { defineConfig, type ReadyRunConfig } from "./config.ts";
 import { doctorCheck, warnUnusedModelsByLabel } from "./doctor.ts";
-import { createTicketWorktree } from "./git.ts";
+import { createTicketWorktree, headCommit } from "./git.ts";
 import { composeWorkerPrompt } from "./prompt.ts";
 import type { Ticket } from "./ticket.ts";
 import type { Effort, Permissions } from "./worker-adapter.ts";
@@ -71,6 +71,17 @@ export async function run(options: RunOptions): Promise<number> {
   ) {
     return 1;
   }
+  let base;
+  try {
+    base = await headCommit(cwd);
+  } catch (error) {
+    return hardStop(
+      stdout,
+      "git",
+      undefined,
+      error instanceof Error ? error.message : undefined,
+    );
+  }
   const context = config.contextFile === undefined
     ? undefined
     : await readFile(join(cwd, config.contextFile), "utf8");
@@ -96,7 +107,7 @@ export async function run(options: RunOptions): Promise<number> {
     const branch = config.tracker.branchName(ticket);
     let worktree;
     try {
-      worktree = await createTicketWorktree(cwd, branch);
+      worktree = await createTicketWorktree(cwd, branch, base);
     } catch (error) {
       return hardStop(
         stdout,

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { test } from "node:test";
 import { promisify } from "node:util";
-import { createTicketWorktree, originRepository, WorktreeExistsError, WorktreeInstallError } from "../src/git.ts";
+import { createTicketWorktree, headCommit, originRepository, WorktreeExistsError, WorktreeInstallError } from "../src/git.ts";
 import { commitMismatchedNpmLockfile, commitNpmConsumer, commitRepoFiles, throwawayRepo } from "./throwaway-repo.ts";
 
 const exec = promisify(execFile);
@@ -83,7 +83,7 @@ test("originRepository is undefined when origin is missing", async () => {
 test("createTicketWorktree checks out the Ticket's Branch in .readyrun/worktrees", async () => {
   const repo = await throwawayRepo();
   try {
-    const worktreePath = await createTicketWorktree(repo.cwd, "readyrun/52");
+    const worktreePath = await createTicketWorktree(repo.cwd, "readyrun/52", await headCommit(repo.cwd));
     assert.equal(
       worktreePath,
       `${repo.cwd}/.readyrun/worktrees/readyrun-52`,
@@ -100,12 +100,58 @@ test("createTicketWorktree checks out the Ticket's Branch in .readyrun/worktrees
   }
 });
 
+test("createTicketWorktree creates the Branch at the base commit it is given, not at the Consumer checkout's HEAD", async () => {
+  const repo = await throwawayRepo();
+  try {
+    const base = await headCommit(repo.cwd);
+    await commitRepoFiles(repo.cwd, { "later.txt": "later\n" });
+    const later = await headCommit(repo.cwd);
+
+    const worktreePath = await createTicketWorktree(repo.cwd, "readyrun/52", base);
+
+    assert.equal(await headCommit(worktreePath), base);
+    await assert.rejects(exec("git", [
+      "-C",
+      worktreePath,
+      "merge-base",
+      "--is-ancestor",
+      later,
+      "HEAD",
+    ]));
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("createTicketWorktree recreates a Worktree whose directory and Branch were deleted by hand", async () => {
+  const repo = await throwawayRepo();
+  try {
+    const base = await headCommit(repo.cwd);
+    const worktreePath = await createTicketWorktree(repo.cwd, "readyrun/52", base);
+    await rm(worktreePath, { recursive: true, force: true });
+    await exec("git", [
+      "-C",
+      repo.cwd,
+      "update-ref",
+      "-d",
+      "refs/heads/readyrun/52",
+    ]);
+
+    assert.equal(
+      await createTicketWorktree(repo.cwd, "readyrun/52", base),
+      worktreePath,
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
 test("createTicketWorktree refuses a Branch that already exists, instead of a raw git error", async () => {
   const repo = await throwawayRepo();
   try {
     await exec("git", ["-C", repo.cwd, "branch", "readyrun/52"]);
     await assert.rejects(
-      createTicketWorktree(repo.cwd, "readyrun/52"),
+      createTicketWorktree(repo.cwd, "readyrun/52", await headCommit(repo.cwd)),
       (error: unknown) => {
         assert.ok(error instanceof WorktreeExistsError);
         assert.match(error.message, /already has a Worktree for branch readyrun\/52/);
@@ -121,7 +167,7 @@ test("createTicketWorktree installs Worktree deps from a Consumer lockfile befor
   const repo = await throwawayRepo();
   try {
     await commitNpmConsumer(repo.cwd);
-    const worktreePath = await createTicketWorktree(repo.cwd, "readyrun/52");
+    const worktreePath = await createTicketWorktree(repo.cwd, "readyrun/52", await headCommit(repo.cwd));
     await access(join(worktreePath, "node_modules"));
   } finally {
     await repo.cleanup();
@@ -141,7 +187,7 @@ test("createTicketWorktree runs pnpm install --frozen-lockfile when packageManag
     });
     let worktreePath = "";
     const args = await withInstallShim(repo.cwd, "pnpm", async () => {
-      worktreePath = await createTicketWorktree(repo.cwd, "readyrun/52");
+      worktreePath = await createTicketWorktree(repo.cwd, "readyrun/52", await headCommit(repo.cwd));
     });
     await access(join(worktreePath, "node_modules"));
     assert.equal(args, "install --frozen-lockfile");
@@ -162,7 +208,7 @@ test("createTicketWorktree runs yarn --frozen-lockfile when the Consumer has a y
     });
     let worktreePath = "";
     const args = await withInstallShim(repo.cwd, "yarn", async () => {
-      worktreePath = await createTicketWorktree(repo.cwd, "readyrun/52");
+      worktreePath = await createTicketWorktree(repo.cwd, "readyrun/52", await headCommit(repo.cwd));
     });
     await access(join(worktreePath, "node_modules"));
     assert.equal(args, "--frozen-lockfile");
@@ -180,7 +226,7 @@ test("createTicketWorktree skips install when the Consumer has no lockfile", asy
         version: "1.0.0",
       }, null, 2)}\n`,
     });
-    const worktreePath = await createTicketWorktree(repo.cwd, "readyrun/52");
+    const worktreePath = await createTicketWorktree(repo.cwd, "readyrun/52", await headCommit(repo.cwd));
     await assert.rejects(access(join(worktreePath, "node_modules")), {
       code: "ENOENT",
     });
@@ -194,7 +240,7 @@ test("createTicketWorktree fails with the install command's output when install 
   try {
     await commitMismatchedNpmLockfile(repo.cwd);
     await assert.rejects(
-      createTicketWorktree(repo.cwd, "readyrun/52"),
+      createTicketWorktree(repo.cwd, "readyrun/52", await headCommit(repo.cwd)),
       (error: unknown) => {
         assert.ok(error instanceof WorktreeInstallError);
         assert.match(error.message, /npm ci/);
@@ -213,7 +259,7 @@ test("createTicketWorktree refuses a leftover Worktree directory even when the B
     const worktreePath = `${repo.cwd}/.readyrun/worktrees/readyrun-52`;
     await mkdir(worktreePath, { recursive: true });
     await assert.rejects(
-      createTicketWorktree(repo.cwd, "readyrun/52"),
+      createTicketWorktree(repo.cwd, "readyrun/52", await headCommit(repo.cwd)),
       WorktreeExistsError,
     );
   } finally {

--- a/test/run-ticket-base.test.ts
+++ b/test/run-ticket-base.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { test } from "node:test";
+import { promisify } from "node:util";
+import { defineConfig, run } from "../src/mod.ts";
+import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
+import { createWorkerAdapter } from "../src/worker-adapter.ts";
+import { ticket } from "./tracker-adapter-contract.ts";
+import { commitRepoFiles, throwawayRepo } from "./throwaway-repo.ts";
+
+const exec = promisify(execFile);
+const silent = { write(_chunk?: string) { return true; } };
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await exec("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+  });
+  return stdout.trim();
+}
+
+test("every Ticket in a Run branches from the base the Run resolved at start, even when the Consumer's checkout moves mid-Run", async () => {
+  const repo = await throwawayRepo();
+  const worker = createWorkerAdapter({
+    async spawn(request) {
+      await commitRepoFiles(repo.cwd, {
+        [`moved-${request.ticket.id}.txt`]: "the Consumer's checkout moved on\n",
+      });
+      return { exitCode: 0 };
+    },
+  });
+  try {
+    const base = await git(repo.cwd, ["rev-parse", "HEAD"]);
+
+    await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "52" }), ticket({ id: "57" })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.notEqual(await git(repo.cwd, ["rev-parse", "HEAD"]), base);
+    assert.equal(await git(repo.cwd, ["rev-parse", "readyrun/52"]), base);
+    assert.equal(await git(repo.cwd, ["rev-parse", "readyrun/57"]), base);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a checkout with no commits to branch from hard-stops the Run at git before a Worker starts", async () => {
+  const repo = await throwawayRepo({ commits: false });
+  const worker = recordingWorker({ exitCode: 0 });
+  const chunks: string[] = [];
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "52" })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.equal(worker.spawns.length, 0);
+    assert.match(chunks.join(""), /Hard stop: failed at git/);
+  } finally {
+    await repo.cleanup();
+  }
+});

--- a/test/throwaway-repo.ts
+++ b/test/throwaway-repo.ts
@@ -14,6 +14,7 @@ export type ThrowawayRepo = {
 
 export async function throwawayRepo(options: {
   defaultBranch?: string;
+  commits?: boolean;
 } = {}): Promise<ThrowawayRepo> {
   const defaultBranch = options.defaultBranch ?? "main";
   await mkdir(tmpRoot, { recursive: true });
@@ -27,9 +28,11 @@ export async function throwawayRepo(options: {
   await exec("git", ["config", "user.name", "ReadyRun"], { cwd });
   await exec("git", ["config", "commit.gpgsign", "false"], { cwd });
   await exec("git", ["config", "init.defaultBranch", defaultBranch], { cwd });
-  await writeFile(join(cwd, "README"), "throwaway\n");
-  await exec("git", ["add", "README"], { cwd });
-  await exec("git", ["commit", "-m", "init"], { cwd });
+  if (options.commits ?? true) {
+    await writeFile(join(cwd, "README"), "throwaway\n");
+    await exec("git", ["add", "README"], { cwd });
+    await exec("git", ["commit", "-m", "init"], { cwd });
+  }
   return {
     cwd,
     async cleanup() {


### PR DESCRIPTION
## Why

A Ticket's Branch began at whatever the Consumer's checkout happened to have at HEAD when the Worker started, so where a Worker began was an accident of the checkout — and it moved if the Consumer switched branches or committed mid-Run. ADR 0028 needs the base to be a commit the Run chose once, at start, because that commit is what the Run Branch's tip will become.

A Worktree kept on failure (ADR 0027) is eventually deleted by hand rather than with `git worktree remove`, and the admin state left under `.git/worktrees/<name>` makes the next add fail over a directory that no longer exists.

## What

`createTicketWorktree` takes the base commit explicitly and creates the Branch at it, after pruning stale Worktree admin state. A Run resolves the base once before its first Ticket and passes the same commit for every Ticket.

## How

A checkout with no commits to branch from cannot yield a base, so the Run hard-stops at the git stage before any Worker starts, per ADR 0013.

Closes #72

Made with [Cursor](https://cursor.com)