### PR TITLE
#73: Verify a Worker committed before a Ticket leaves the Frontier

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -99,7 +99,7 @@ _Avoid_: max mode (Cursor's interactive slash command), ultracode (a Claude Code
 - A **Worker**’s model: config default is required (**Doctor** fail if missing). CLI `--model` overrides that default for the **Run**. A label map may override per **Ticket**. The **Ticket** body does not name a model.
 - The **Worker** prompt is owned by the package: loop rules plus **Tracker Adapter** copy (this **Ticket**’s id, title, body, URL). Loop rules tell the **Worker** it will not get a reply and must not ask the **Consumer**; a blocking question is a failed **Ticket**, not a pause. A **Consumer** may append a repo context file from config. That file does not replace tracker instructions. There is no repo `prompt.md` that owns the loop.
 - When a **Worker** succeeds, the **Ticket** must leave the **Frontier**. The **Tracker Adapter** has a default for that (Linear: In Review, not Done; GitHub: drop the frontier label, comment, do not close). A **Consumer** may override; they do not have to write a hook.
-- A **Run** hard-stops (no skip, no retry-forever) on **Tracker** API or auth failure, **Branch**/**Worktree** failure, **Worker** missing or not logged in at spawn, or **Worker** non-zero exit. Empty **Frontier** and cap are clean stops. The harness owns **Tracker** auth; the coding CLI owns its own login.
+- A **Run** hard-stops (no skip, no retry-forever) on **Tracker** API or auth failure, **Branch**/**Worktree** failure, **Worker** missing or not logged in at spawn, **Worker** non-zero exit, or a **Worker** that exits 0 leaving its **Worktree** dirty or its **Branch** unchanged. Empty **Frontier** and cap are clean stops. The harness owns **Tracker** auth; the coding CLI owns its own login.
 
 ## Example dialogue
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -113,6 +113,25 @@ export async function headCommit(cwd: string): Promise<string> {
   return await git(cwd, ["rev-parse", "HEAD"]);
 }
 
+export async function worktreeIsClean(worktreePath: string): Promise<boolean> {
+  return await git(worktreePath, ["status", "--porcelain"]) === "";
+}
+
+// Read the Branch ref, not the Worktree's HEAD: a Worker that committed
+// somewhere else left the Ticket's Branch as empty as one that did nothing.
+export async function branchHasCommitsSince(
+  cwd: string,
+  branch: string,
+  base: string,
+): Promise<boolean> {
+  const count = await git(cwd, [
+    "rev-list",
+    "--count",
+    `${base}..refs/heads/${branch}`,
+  ]);
+  return count !== "0";
+}
+
 export async function createTicketWorktree(
   cwd: string,
   branch: string,

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,5 +1,7 @@
 const LOOP_RULES = `You are implementing exactly one Ticket. Do not start neighbouring work.
 
+Commit your work on the Branch already checked out in this directory. ReadyRun checks that you did: exiting with uncommitted changes, or with nothing committed, is a failed Ticket.
+
 You will not get a reply. Do not ask the Consumer. Decide from the Ticket, the context file, and the repo (CONTEXT.md, docs/adr/). A blocking question is a failed Ticket, not a pause.
 
 Do not invent a Tracker.

--- a/src/run.ts
+++ b/src/run.ts
@@ -2,7 +2,12 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { defineConfig, type ReadyRunConfig } from "./config.ts";
 import { doctorCheck, warnUnusedModelsByLabel } from "./doctor.ts";
-import { createTicketWorktree, headCommit } from "./git.ts";
+import {
+  branchHasCommitsSince,
+  createTicketWorktree,
+  headCommit,
+  worktreeIsClean,
+} from "./git.ts";
 import { composeWorkerPrompt } from "./prompt.ts";
 import type { Ticket } from "./ticket.ts";
 import type { Effort, Permissions } from "./worker-adapter.ts";
@@ -137,6 +142,37 @@ export async function run(options: RunOptions): Promise<number> {
         "worker",
         ticket.id,
         `exit code ${result.exitCode}`,
+      );
+    }
+    // Exit 0 is not success on its own: a Worker that did nothing also exits 0
+    // and also leaves a clean tree (ADR 0027).
+    let clean;
+    let committed;
+    try {
+      clean = await worktreeIsClean(worktree);
+      committed = await branchHasCommitsSince(cwd, branch, base);
+    } catch (error) {
+      return hardStop(
+        stdout,
+        "git",
+        ticket.id,
+        error instanceof Error ? error.message : undefined,
+      );
+    }
+    if (!clean) {
+      return hardStop(
+        stdout,
+        "worker",
+        ticket.id,
+        `left work uncommitted in ${worktree}`,
+      );
+    }
+    if (!committed) {
+      return hardStop(
+        stdout,
+        "worker",
+        ticket.id,
+        `committed nothing on ${branch}`,
       );
     }
     try {

--- a/src/testing/mod.ts
+++ b/src/testing/mod.ts
@@ -2,6 +2,7 @@ export { memoryTracker } from "./memory-tracker.ts";
 export type { MemoryTrackerOptions } from "./memory-tracker.ts";
 export { recordingWorker } from "./recording-worker.ts";
 export type {
+  LeftWork,
   RecordingWorker,
   RecordingWorkerOptions,
 } from "./recording-worker.ts";

--- a/src/testing/recording-worker.ts
+++ b/src/testing/recording-worker.ts
@@ -1,11 +1,22 @@
+import { execFile } from "node:child_process";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
 import {
   createWorkerAdapter,
   type SpawnRequest,
   type WorkerAdapter,
 } from "../worker-adapter.ts";
 
+const exec = promisify(execFile);
+
+// What the double leaves behind in the Worktree it was spawned in. The default
+// is "committed", because that is what the prompt tells a Worker to do.
+export type LeftWork = "committed" | "uncommitted" | "none";
+
 export type RecordingWorkerOptions = {
   exitCode?: number;
+  work?: LeftWork;
 };
 
 export type RecordingWorker = WorkerAdapter & {
@@ -17,15 +28,39 @@ export function recordingWorker(
 ): RecordingWorker {
   const spawns: SpawnRequest[] = [];
   const exitCode = options.exitCode ?? 0;
+  const work = options.work ?? "committed";
 
   return Object.assign(
     createWorkerAdapter({
       effortFlag: "--effort",
-      spawn(request: SpawnRequest) {
+      async spawn(request: SpawnRequest) {
         spawns.push(request);
-        return Promise.resolve({ exitCode });
+        await leaveWork(work, request);
+        return { exitCode };
       },
     }),
     { spawns },
   );
+}
+
+async function leaveWork(
+  work: LeftWork,
+  request: SpawnRequest,
+): Promise<void> {
+  if (work === "none") {
+    return;
+  }
+  const file = `ticket-${request.ticket.id}.txt`;
+  await writeFile(join(request.cwd, file), `${request.ticket.title}\n`);
+  if (work === "uncommitted") {
+    return;
+  }
+  await exec("git", ["-C", request.cwd, "add", "--", file]);
+  await exec("git", [
+    "-C",
+    request.cwd,
+    "commit",
+    "-m",
+    `Ticket ${request.ticket.id}`,
+  ]);
 }

--- a/test/run-frontier.test.ts
+++ b/test/run-frontier.test.ts
@@ -1,22 +1,12 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
 import { test } from "node:test";
-import { promisify } from "node:util";
 import { defineConfig, run } from "../src/mod.ts";
 import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
 import { createWorkerAdapter } from "../src/worker-adapter.ts";
 import { ticket } from "./tracker-adapter-contract.ts";
-import { throwawayRepo } from "./throwaway-repo.ts";
+import { commitWorkerWork, git, throwawayRepo } from "./throwaway-repo.ts";
 
-const exec = promisify(execFile);
 const silent = { write(_chunk?: string) { return true; } };
-
-async function git(cwd: string, args: string[]): Promise<string> {
-  const { stdout } = await exec("git", ["-C", cwd, ...args], {
-    encoding: "utf8",
-  });
-  return stdout.trim();
-}
 
 test("a blocked Ticket is never picked, even if it matches the selector", async () => {
   const repo = await throwawayRepo();
@@ -217,11 +207,12 @@ test("a v0 Run starts one Worker at a time; each Ticket still gets its own Branc
   let inFlight = 0;
   let maxInFlight = 0;
   const worker = createWorkerAdapter({
-    async spawn() {
+    async spawn(request) {
       inFlight += 1;
       maxInFlight = Math.max(maxInFlight, inFlight);
       await new Promise((resolve) => setTimeout(resolve, 25));
       inFlight -= 1;
+      await commitWorkerWork(request);
       return { exitCode: 0 };
     },
   });

--- a/test/run-spawn-payload.test.ts
+++ b/test/run-spawn-payload.test.ts
@@ -440,6 +440,34 @@ test("the Worker prompt tells the Worker not to invent a Tracker, fabricate Tick
   }
 });
 
+test("the Worker prompt tells the Worker to commit its work, because ReadyRun checks that it did", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  try {
+    await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    const prompt = worker.spawns[0]?.prompt;
+    assert.ok(prompt);
+    assert.match(prompt, /Commit your work on the Branch/);
+    assert.match(prompt, /uncommitted changes|nothing committed/);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
 test("the Worker prompt tells the Worker it will not get a reply and must not ask the Consumer", async () => {
   const repo = await throwawayRepo();
   const worker = recordingWorker({ exitCode: 0 });

--- a/test/run-ticket-base.test.ts
+++ b/test/run-ticket-base.test.ts
@@ -1,27 +1,23 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
 import { test } from "node:test";
-import { promisify } from "node:util";
 import { defineConfig, run } from "../src/mod.ts";
 import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
 import { createWorkerAdapter } from "../src/worker-adapter.ts";
 import { ticket } from "./tracker-adapter-contract.ts";
-import { commitRepoFiles, throwawayRepo } from "./throwaway-repo.ts";
+import {
+  commitRepoFiles,
+  commitWorkerWork,
+  git,
+  throwawayRepo,
+} from "./throwaway-repo.ts";
 
-const exec = promisify(execFile);
 const silent = { write(_chunk?: string) { return true; } };
-
-async function git(cwd: string, args: string[]): Promise<string> {
-  const { stdout } = await exec("git", ["-C", cwd, ...args], {
-    encoding: "utf8",
-  });
-  return stdout.trim();
-}
 
 test("every Ticket in a Run branches from the base the Run resolved at start, even when the Consumer's checkout moves mid-Run", async () => {
   const repo = await throwawayRepo();
   const worker = createWorkerAdapter({
     async spawn(request) {
+      await commitWorkerWork(request);
       await commitRepoFiles(repo.cwd, {
         [`moved-${request.ticket.id}.txt`]: "the Consumer's checkout moved on\n",
       });
@@ -47,8 +43,8 @@ test("every Ticket in a Run branches from the base the Run resolved at start, ev
     });
 
     assert.notEqual(await git(repo.cwd, ["rev-parse", "HEAD"]), base);
-    assert.equal(await git(repo.cwd, ["rev-parse", "readyrun/52"]), base);
-    assert.equal(await git(repo.cwd, ["rev-parse", "readyrun/57"]), base);
+    assert.equal(await git(repo.cwd, ["rev-parse", "readyrun/52^"]), base);
+    assert.equal(await git(repo.cwd, ["rev-parse", "readyrun/57^"]), base);
   } finally {
     await repo.cleanup();
   }

--- a/test/run-worker-commit.test.ts
+++ b/test/run-worker-commit.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { access, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { test } from "node:test";
+import { defineConfig, run } from "../src/mod.ts";
+import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
+import { createWorkerAdapter } from "../src/worker-adapter.ts";
+import { ticket } from "./tracker-adapter-contract.ts";
+import { git, throwawayRepo } from "./throwaway-repo.ts";
+
+const silent = { write(_chunk?: string) { return true; } };
+
+function tracker() {
+  return memoryTracker({
+    tickets: [ticket({ id: "52" }), ticket({ id: "57" })],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+  });
+}
+
+test("a Worker exiting 0 with a dirty Worktree hard-stops the Run and leaves its Ticket on the Frontier", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0, work: "uncommitted" });
+  const frontier = tracker();
+  const chunks: string[] = [];
+  try {
+    const exitCode = await run({
+      config: defineConfig({ tracker: frontier, worker, model: "composer-2" }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(worker.spawns.map((spawn) => spawn.ticket.id), ["52"]);
+    assert.deepEqual(
+      (await frontier.frontier()).map((item) => item.id),
+      ["52", "57"],
+    );
+    assert.match(
+      chunks.join(""),
+      /Hard stop: Ticket 52 failed at worker: left work uncommitted in .*readyrun-52/,
+    );
+    const worktree = worker.spawns[0]?.cwd;
+    assert.ok(worktree);
+    await access(join(worktree, "ticket-52.txt"));
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a Worker exiting 0 having committed nothing hard-stops the Run and leaves its Ticket on the Frontier", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0, work: "none" });
+  const frontier = tracker();
+  const chunks: string[] = [];
+  try {
+    const exitCode = await run({
+      config: defineConfig({ tracker: frontier, worker, model: "composer-2" }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(worker.spawns.map((spawn) => spawn.ticket.id), ["52"]);
+    assert.deepEqual(
+      (await frontier.frontier()).map((item) => item.id),
+      ["52", "57"],
+    );
+    assert.match(
+      chunks.join(""),
+      /Hard stop: Ticket 52 failed at worker: committed nothing on readyrun\/52/,
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a Worker exiting 0 with a clean Worktree and a commit on its Branch takes its Ticket off the Frontier", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0, work: "committed" });
+  const frontier = tracker();
+  try {
+    const base = await git(repo.cwd, ["rev-parse", "HEAD"]);
+
+    const exitCode = await run({
+      config: defineConfig({ tracker: frontier, worker, model: "composer-2" }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(worker.spawns.map((spawn) => spawn.ticket.id), ["52", "57"]);
+    assert.deepEqual(await frontier.frontier(), []);
+    assert.equal(
+      await git(repo.cwd, ["rev-list", "--count", `${base}..readyrun/52`]),
+      "1",
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a Worker that commits on another Branch leaves its own Branch empty and hard-stops the Run", async () => {
+  const repo = await throwawayRepo();
+  const worker = createWorkerAdapter({
+    async spawn(request) {
+      await git(request.cwd, ["checkout", "-b", "somewhere-else"]);
+      await writeFile(
+        join(request.cwd, "elsewhere.txt"),
+        "not on the Ticket's Branch\n",
+      );
+      await git(request.cwd, ["add", "--", "elsewhere.txt"]);
+      await git(request.cwd, ["commit", "-m", "elsewhere"]);
+      return { exitCode: 0 };
+    },
+  });
+  const frontier = tracker();
+  const chunks: string[] = [];
+  try {
+    const exitCode = await run({
+      config: defineConfig({ tracker: frontier, worker, model: "composer-2" }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(
+      (await frontier.frontier()).map((item) => item.id),
+      ["52", "57"],
+    );
+    assert.match(
+      chunks.join(""),
+      /Hard stop: Ticket 52 failed at worker: committed nothing on readyrun\/52/,
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});

--- a/test/throwaway-repo.ts
+++ b/test/throwaway-repo.ts
@@ -3,9 +3,17 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+import type { SpawnRequest } from "../src/worker-adapter.ts";
 
 const exec = promisify(execFile);
 const tmpRoot = join(fileURLToPath(new URL(".", import.meta.url)), ".tmp");
+
+export async function git(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await exec("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+  });
+  return stdout.trim();
+}
 
 export type ThrowawayRepo = {
   cwd: string;
@@ -44,13 +52,23 @@ export async function throwawayRepo(options: {
 export async function commitRepoFiles(
   cwd: string,
   files: Record<string, string>,
+  message = "consumer manifest",
 ): Promise<void> {
   for (const [name, contents] of Object.entries(files)) {
     await mkdir(join(cwd, name, ".."), { recursive: true });
     await writeFile(join(cwd, name), contents);
   }
   await exec("git", ["add", "--", ...Object.keys(files)], { cwd });
-  await exec("git", ["commit", "-m", "consumer manifest"], { cwd });
+  await exec("git", ["commit", "-m", message], { cwd });
+}
+
+// A Worker doing what the prompt tells it: committing its work on its Branch.
+export async function commitWorkerWork(request: SpawnRequest): Promise<void> {
+  await commitRepoFiles(
+    request.cwd,
+    { [`ticket-${request.ticket.id}.txt`]: "the Worker's work\n" },
+    `Ticket ${request.ticket.id}`,
+  );
 }
 
 export async function commitNpmConsumer(cwd: string): Promise<void> {


### PR DESCRIPTION
## Why

A **Worker**'s exit 0 was success on its own, so a **Worker** that did nothing at all — exit 0, clean tree, empty **Branch** — took its **Ticket** off the **Frontier**. That is the silent lie ADR 0013 exists to prevent, and ADR 0027 says exit 0 is only success when the **Worktree** is clean and the **Branch** carries work.

The prompt also never told the **Worker** to commit, which #73 assumes it does. Verifying an instruction we had not given would have hard-stopped every real **Run**.

## What

After exit 0, the **Run** checks the **Worktree** is clean and the **Ticket**'s **Branch** carries a commit past the base the **Run** resolved (#72). Either failing hard-stops, so the **Ticket** stays on the **Frontier** and the **Worktree** stays on disk, distinguishable as `left work uncommitted in <path>` versus `committed nothing on <branch>` (#62's wording). `LOOP_RULES` now tells the **Worker** to commit.

## How

The commit check reads the **Branch** ref, not the **Worktree**'s HEAD, so a **Worker** that commits somewhere else is caught too. `recordingWorker` gained `work: "committed" | "uncommitted" | "none"`, defaulting to committed, because a double that never commits would now hard-stop every existing **Run** test.

## Workarounds

An empty commit still passes the check, and a **Consumer** that does not ignore its install output would read as dirty. Both are deliberate scope calls, filed as #79 and #80.

Closes #73

Made with [Cursor](https://cursor.com)