### PR TITLE
Remove a Ticket's Worktree on success, keep it on a hard stop (#74)

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -171,6 +171,15 @@ export async function createTicketWorktree(
   return worktreePath;
 }
 
+// Plain `remove`, not `--force`: a Worktree still holding work is a hard stop
+// the Run has already refused to reach, so failing loudly here is right.
+export async function removeTicketWorktree(
+  cwd: string,
+  worktreePath: string,
+): Promise<void> {
+  await git(cwd, ["worktree", "remove", worktreePath]);
+}
+
 async function installWorktreeDependencies(worktreePath: string): Promise<void> {
   const command = await detectInstallCommand(worktreePath);
   if (command === undefined) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -6,6 +6,7 @@ import {
   branchHasCommitsSince,
   createTicketWorktree,
   headCommit,
+  removeTicketWorktree,
   worktreeIsClean,
 } from "./git.ts";
 import { composeWorkerPrompt } from "./prompt.ts";
@@ -183,6 +184,18 @@ export async function run(options: RunOptions): Promise<number> {
       }
     } catch {
       return hardStop(stdout, "tracker", ticket.id);
+    }
+    // Last, so that a hard stop at any earlier stage leaves the Worktree on
+    // disk for the Consumer to look at (ADR 0027).
+    try {
+      await removeTicketWorktree(cwd, worktree);
+    } catch (error) {
+      return hardStop(
+        stdout,
+        "git",
+        ticket.id,
+        error instanceof Error ? error.message : undefined,
+      );
     }
   }
   return 0;

--- a/test/run-frontier.test.ts
+++ b/test/run-frontier.test.ts
@@ -206,11 +206,17 @@ test("a v0 Run starts one Worker at a time; each Ticket still gets its own Branc
   const repo = await throwawayRepo();
   let inFlight = 0;
   let maxInFlight = 0;
+  const worktreesAtSpawn: Record<string, string> = {};
   const worker = createWorkerAdapter({
     async spawn(request) {
       inFlight += 1;
       maxInFlight = Math.max(maxInFlight, inFlight);
       await new Promise((resolve) => setTimeout(resolve, 25));
+      worktreesAtSpawn[request.ticket.id] = await git(repo.cwd, [
+        "worktree",
+        "list",
+        "--porcelain",
+      ]);
       inFlight -= 1;
       await commitWorkerWork(request);
       return { exitCode: 0 };
@@ -235,9 +241,8 @@ test("a v0 Run starts one Worker at a time; each Ticket still gets its own Branc
     assert.equal(maxInFlight, 1);
     await git(repo.cwd, ["rev-parse", "--verify", "refs/heads/readyrun/52"]);
     await git(repo.cwd, ["rev-parse", "--verify", "refs/heads/readyrun/57"]);
-    const worktrees = await git(repo.cwd, ["worktree", "list", "--porcelain"]);
-    assert.match(worktrees, /readyrun\/52/);
-    assert.match(worktrees, /readyrun\/57/);
+    assert.match(worktreesAtSpawn["52"] ?? "", /readyrun\/52/);
+    assert.match(worktreesAtSpawn["57"] ?? "", /readyrun\/57/);
     assert.equal(await git(repo.cwd, ["rev-parse", "--abbrev-ref", "HEAD"]), "main");
   } finally {
     await repo.cleanup();

--- a/test/run-one-ticket.test.ts
+++ b/test/run-one-ticket.test.ts
@@ -8,7 +8,11 @@ import { defineConfig, run } from "../src/mod.ts";
 import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
 import type { Ticket } from "../src/mod.ts";
 import { createWorkerAdapter } from "../src/worker-adapter.ts";
-import { commitNpmConsumer, throwawayRepo } from "./throwaway-repo.ts";
+import {
+  commitNpmConsumer,
+  commitWorkerWork,
+  throwawayRepo,
+} from "./throwaway-repo.ts";
 
 const exec = promisify(execFile);
 const silent = { write(_chunk?: string) { return true; } };
@@ -130,7 +134,16 @@ test("ReadyRun refuses to start a Worker on the default branch", async () => {
 
 test("the Worker runs in a git Worktree on that Branch, not in the Consumer's primary checkout", async () => {
   const repo = await throwawayRepo();
-  const worker = recordingWorker({ exitCode: 0 });
+  let cwdAtSpawn: string | undefined;
+  let branchAtSpawn: string | undefined;
+  const worker = createWorkerAdapter({
+    async spawn(request) {
+      cwdAtSpawn = request.cwd;
+      branchAtSpawn = await git(request.cwd, ["rev-parse", "--abbrev-ref", "HEAD"]);
+      await commitWorkerWork(request);
+      return { exitCode: 0 };
+    },
+  });
   try {
     await run({
       config: defineConfig({
@@ -147,10 +160,9 @@ test("the Worker runs in a git Worktree on that Branch, not in the Consumer's pr
       stdout: silent,
     });
 
-    const spawn = worker.spawns[0];
-    assert.ok(spawn?.cwd);
-    assert.notEqual(spawn.cwd, repo.cwd);
-    assert.equal(await git(spawn.cwd, ["rev-parse", "--abbrev-ref", "HEAD"]), "readyrun/52");
+    assert.ok(cwdAtSpawn);
+    assert.notEqual(cwdAtSpawn, repo.cwd);
+    assert.equal(branchAtSpawn, "readyrun/52");
     assert.equal(await git(repo.cwd, ["rev-parse", "--abbrev-ref", "HEAD"]), "main");
   } finally {
     await repo.cleanup();

--- a/test/run-worktree-lifetime.test.ts
+++ b/test/run-worktree-lifetime.test.ts
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import { access } from "node:fs/promises";
+import { join } from "node:path";
+import { test } from "node:test";
+import { createTrackerAdapter, defineConfig, run } from "../src/mod.ts";
+import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
+import { createWorkerAdapter } from "../src/worker-adapter.ts";
+import { ticket } from "./tracker-adapter-contract.ts";
+import { commitWorkerWork, git, throwawayRepo } from "./throwaway-repo.ts";
+
+const silent = { write(_chunk?: string) { return true; } };
+
+function tracker() {
+  return memoryTracker({
+    tickets: [ticket({ id: "52" }), ticket({ id: "57" })],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+  });
+}
+
+function worktreeOf(cwd: string, ticketId: string): string {
+  return join(cwd, ".readyrun", "worktrees", `readyrun-${ticketId}`);
+}
+
+async function onDisk(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test("a verified-successful Ticket's Worktree is gone before the next Ticket starts, and its Branch still carries the work", async () => {
+  const repo = await throwawayRepo();
+  const ticket52WorktreeAtSpawnOf: Record<string, boolean> = {};
+  const worker = createWorkerAdapter({
+    async spawn(request) {
+      ticket52WorktreeAtSpawnOf[request.ticket.id] = await onDisk(
+        worktreeOf(repo.cwd, "52"),
+      );
+      await commitWorkerWork(request);
+      return { exitCode: 0 };
+    },
+  });
+  try {
+    const base = await git(repo.cwd, ["rev-parse", "HEAD"]);
+
+    const exitCode = await run({
+      config: defineConfig({ tracker: tracker(), worker, model: "composer-2" }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(ticket52WorktreeAtSpawnOf, { 52: true, 57: false });
+    assert.equal(await onDisk(worktreeOf(repo.cwd, "57")), false);
+    assert.equal(
+      await git(repo.cwd, ["rev-list", "--count", `${base}..readyrun/52`]),
+      "1",
+    );
+    assert.equal(
+      await git(repo.cwd, ["rev-list", "--count", `${base}..readyrun/57`]),
+      "1",
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a Worker exiting non-zero leaves its Worktree on disk to look at", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 42 });
+  try {
+    const exitCode = await run({
+      config: defineConfig({ tracker: tracker(), worker, model: "composer-2" }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(exitCode, 1);
+    assert.equal(await onDisk(worktreeOf(repo.cwd, "52")), true);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a Worker exiting 0 having committed nothing leaves its Worktree on disk; removal never runs before the success check", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0, work: "none" });
+  try {
+    const exitCode = await run({
+      config: defineConfig({ tracker: tracker(), worker, model: "composer-2" }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(exitCode, 1);
+    assert.equal(await onDisk(worktreeOf(repo.cwd, "52")), true);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a Tracker failure finishing a Ticket leaves the Worktree on disk even though the Worker succeeded", async () => {
+  const repo = await throwawayRepo();
+  const inner = tracker();
+  const worker = recordingWorker({ exitCode: 0 });
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: createTrackerAdapter({
+          frontier: () => inner.frontier(),
+          branchName: (item) => inner.branchName(item),
+          leaveFrontier() {
+            return Promise.reject(new Error("GitHub API 500"));
+          },
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(exitCode, 1);
+    assert.equal(await onDisk(worktreeOf(repo.cwd, "52")), true);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("re-running a Ticket whose Worktree was kept still hard-stops with WorktreeExistsError", async () => {
+  const repo = await throwawayRepo();
+  const chunks: string[] = [];
+  try {
+    const failed = await run({
+      config: defineConfig({
+        tracker: tracker(),
+        worker: recordingWorker({ exitCode: 42 }),
+        model: "composer-2",
+      }),
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+    assert.equal(failed, 1);
+
+    const rerun = await run({
+      config: defineConfig({
+        tracker: tracker(),
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+
+    assert.equal(rerun, 1);
+    assert.match(
+      chunks.join(""),
+      /Hard stop: Ticket 52 failed at git: ReadyRun already has a Worktree for branch readyrun\/52/,
+    );
+    assert.equal(await onDisk(worktreeOf(repo.cwd, "52")), true);
+  } finally {
+    await repo.cleanup();
+  }
+});


### PR DESCRIPTION
## Why

Closes #74.

Every Worktree a Run created outlived it, so `.readyrun/worktrees/` filled with directories nobody reads and the next Run over the same Ticket collided with them. ADR 0027 makes the Worktree disposable: it is only where a Worker ran, and the Branch carries the work forward. A failure is the one case worth keeping on disk, because that is the evidence somebody still has to look at.

This also unblocks #75 — a Branch cannot be deleted while a Worktree still has it checked out.

## What

A verified-successful Ticket's Worktree is removed with `git worktree remove`. Any hard stop leaves the in-flight Worktree where it is.

## How

Removal is the last step of a successful iteration, after `leaveFrontier`, so a hard stop at *any* earlier stage — tracker, git, spawn, worker, the clean/committed success check, or finishing the Ticket on the Tracker — still leaves the directory behind. Plain `remove` rather than `--force`, since a Worktree still holding work is a hard stop the Run has already refused to reach.

Two existing tests inspected the Worktree after a successful Run, which no longer exists. Rather than weaken them, their observations moved to while the Worker is running, which is when the behaviour they are named for actually holds.

## Workarounds

If `git worktree remove` itself fails, the Ticket has already left the Frontier while the Run exits 1. The alternative ordering — removing before `leaveFrontier` — trades that edge case for a Tracker failure destroying the Worktree, which the acceptance criteria rule out explicitly.

Made with [Cursor](https://cursor.com)