### PR TITLE
#75: Collect a Run's Tickets onto one Run Branch

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -171,6 +171,50 @@ export async function createTicketWorktree(
   return worktreePath;
 }
 
+export type CollectOntoRunBranchOptions = {
+  runBranch: string;
+  branch: string;
+  base: string;
+  message: string;
+};
+
+// Merges with plumbing rather than `git merge`, because the Run Branch never
+// needs a working tree of its own and the Consumer's checkout is theirs to
+// stand on: a Run collects Tickets without moving anyone (ADR 0028).
+export async function collectOntoRunBranch(
+  cwd: string,
+  options: CollectOntoRunBranchOptions,
+): Promise<string> {
+  const runRef = `refs/heads/${options.runBranch}`;
+  // Created at the first merge, so a Run that lands nothing leaves no ref.
+  if (!await branchExists(cwd, options.runBranch)) {
+    await git(cwd, ["branch", options.runBranch, options.base]);
+  }
+  const tip = await git(cwd, ["rev-parse", runRef]);
+  const collected = await git(cwd, [
+    "rev-parse",
+    `refs/heads/${options.branch}`,
+  ]);
+  const tree = await git(cwd, ["merge-tree", "--write-tree", tip, collected]);
+  // Two parents and no fast-forward: one Ticket is one entry in the Run
+  // Branch's first-parent history, with the Worker's own commits underneath.
+  const merge = await git(cwd, [
+    "commit-tree",
+    tree,
+    "-p",
+    tip,
+    "-p",
+    collected,
+    "-m",
+    options.message,
+  ]);
+  await git(cwd, ["update-ref", runRef, merge, tip]);
+  // `--force` because the Branch is merged into the Run Branch, which is not
+  // the branch the Consumer's checkout is on, so git cannot see that itself.
+  await git(cwd, ["branch", "--delete", "--force", options.branch]);
+  return merge;
+}
+
 // Plain `remove`, not `--force`: a Worktree still holding work is a hard stop
 // the Run has already refused to reach, so failing loudly here is right.
 export async function removeTicketWorktree(

--- a/src/git.ts
+++ b/src/git.ts
@@ -91,12 +91,14 @@ function parseOwnerRepo(url: string): string | undefined {
   return path?.[1];
 }
 
-async function branchExists(cwd: string, branch: string): Promise<boolean> {
+async function branchTip(
+  cwd: string,
+  branch: string,
+): Promise<string | undefined> {
   try {
-    await git(cwd, ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`]);
-    return true;
+    return await git(cwd, ["rev-parse", "--verify", `refs/heads/${branch}`]);
   } catch {
-    return false;
+    return undefined;
   }
 }
 
@@ -149,7 +151,9 @@ export async function createTicketWorktree(
     branch.replaceAll("/", "-"),
   );
 
-  if (await branchExists(cwd, branch) || await pathExists(worktreePath)) {
+  if (
+    await branchTip(cwd, branch) !== undefined || await pathExists(worktreePath)
+  ) {
     throw new WorktreeExistsError(branch, worktreePath);
   }
 
@@ -186,13 +190,11 @@ export async function collectOntoRunBranch(
   options: CollectOntoRunBranchOptions,
 ): Promise<string> {
   const runRef = `refs/heads/${options.runBranch}`;
-  // Created at the first merge, so a Run that lands nothing leaves no ref.
-  if (!await branchExists(cwd, options.runBranch)) {
-    await git(cwd, ["branch", options.runBranch, options.base]);
-  }
-  const tip = await git(cwd, ["rev-parse", runRef]);
+  const existing = await branchTip(cwd, options.runBranch);
+  const tip = existing ?? options.base;
   const collected = await git(cwd, [
     "rev-parse",
+    "--verify",
     `refs/heads/${options.branch}`,
   ]);
   const tree = await git(cwd, ["merge-tree", "--write-tree", tip, collected]);
@@ -208,7 +210,10 @@ export async function collectOntoRunBranch(
     "-m",
     options.message,
   ]);
-  await git(cwd, ["update-ref", runRef, merge, tip]);
+  // The merge that lands is what writes the ref — an empty old value where the
+  // Run Branch does not exist yet, so a Run that never lands a Ticket, or whose
+  // first merge fails, leaves no Run Branch behind.
+  await git(cwd, ["update-ref", runRef, merge, existing ?? ""]);
   // `--force` because the Branch is merged into the Run Branch, which is not
   // the branch the Consumer's checkout is on, so git cannot see that itself.
   await git(cwd, ["branch", "--delete", "--force", options.branch]);

--- a/src/run.ts
+++ b/src/run.ts
@@ -99,11 +99,9 @@ export async function run(options: RunOptions): Promise<number> {
     return 1;
   }
   const runBranch = runBranchName(new Date());
-  // Where the next Ticket's Branch is cut from: the base the Run resolved at
-  // start until a Ticket lands, then the Run Branch's tip (ADR 0028).
-  let tip;
+  let base;
   try {
-    tip = await headCommit(cwd);
+    base = await headCommit(cwd);
   } catch (error) {
     return hardStop(
       stdout,
@@ -112,6 +110,9 @@ export async function run(options: RunOptions): Promise<number> {
       error instanceof Error ? error.message : undefined,
     );
   }
+  // A Ticket's Branch is cut from the Run Branch's tip, which until the first
+  // Ticket lands is the base the Run resolved at start (ADR 0028).
+  let runBranchTip = base;
   const context = config.contextFile === undefined
     ? undefined
     : await readFile(join(cwd, config.contextFile), "utf8");
@@ -137,7 +138,7 @@ export async function run(options: RunOptions): Promise<number> {
     const branch = config.tracker.branchName(ticket);
     let worktree;
     try {
-      worktree = await createTicketWorktree(cwd, branch, tip);
+      worktree = await createTicketWorktree(cwd, branch, runBranchTip);
     } catch (error) {
       return hardStop(
         stdout,
@@ -175,7 +176,7 @@ export async function run(options: RunOptions): Promise<number> {
     let committed;
     try {
       clean = await worktreeIsClean(worktree);
-      committed = await branchHasCommitsSince(cwd, branch, tip);
+      committed = await branchHasCommitsSince(cwd, branch, runBranchTip);
     } catch (error) {
       return hardStop(
         stdout,
@@ -214,10 +215,10 @@ export async function run(options: RunOptions): Promise<number> {
     // be deleted while a Worktree still has it checked out.
     try {
       await removeTicketWorktree(cwd, worktree);
-      tip = await collectOntoRunBranch(cwd, {
+      runBranchTip = await collectOntoRunBranch(cwd, {
         runBranch,
         branch,
-        base: tip,
+        base,
         message: mergeMessage(ticket),
       });
     } catch (error) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -4,6 +4,7 @@ import { defineConfig, type ReadyRunConfig } from "./config.ts";
 import { doctorCheck, warnUnusedModelsByLabel } from "./doctor.ts";
 import {
   branchHasCommitsSince,
+  collectOntoRunBranch,
   createTicketWorktree,
   headCommit,
   removeTicketWorktree,
@@ -43,6 +44,26 @@ function resolveModel(
   return mapped ?? runModel ?? config.model;
 }
 
+function runBranchName(startedAt: Date): string {
+  const pad = (value: number) => String(value).padStart(2, "0");
+  const stamp = [
+    startedAt.getFullYear(),
+    pad(startedAt.getMonth() + 1),
+    pad(startedAt.getDate()),
+    "-",
+    pad(startedAt.getHours()),
+    pad(startedAt.getMinutes()),
+    pad(startedAt.getSeconds()),
+  ].join("");
+  return `readyrun/run-${stamp}`;
+}
+
+// The merge is the only commit ReadyRun writes, so its message is derived from
+// the Ticket the way the Branch name is rather than authored about the code.
+function mergeMessage(ticket: Ticket): string {
+  return `Ticket ${ticket.id}: ${ticket.title}`;
+}
+
 type HardStopStage = "tracker" | "git" | "spawn" | "worker";
 
 function hardStop(
@@ -77,9 +98,12 @@ export async function run(options: RunOptions): Promise<number> {
   ) {
     return 1;
   }
-  let base;
+  const runBranch = runBranchName(new Date());
+  // Where the next Ticket's Branch is cut from: the base the Run resolved at
+  // start until a Ticket lands, then the Run Branch's tip (ADR 0028).
+  let tip;
   try {
-    base = await headCommit(cwd);
+    tip = await headCommit(cwd);
   } catch (error) {
     return hardStop(
       stdout,
@@ -113,7 +137,7 @@ export async function run(options: RunOptions): Promise<number> {
     const branch = config.tracker.branchName(ticket);
     let worktree;
     try {
-      worktree = await createTicketWorktree(cwd, branch, base);
+      worktree = await createTicketWorktree(cwd, branch, tip);
     } catch (error) {
       return hardStop(
         stdout,
@@ -151,7 +175,7 @@ export async function run(options: RunOptions): Promise<number> {
     let committed;
     try {
       clean = await worktreeIsClean(worktree);
-      committed = await branchHasCommitsSince(cwd, branch, base);
+      committed = await branchHasCommitsSince(cwd, branch, tip);
     } catch (error) {
       return hardStop(
         stdout,
@@ -185,10 +209,17 @@ export async function run(options: RunOptions): Promise<number> {
     } catch {
       return hardStop(stdout, "tracker", ticket.id);
     }
-    // Last, so that a hard stop at any earlier stage leaves the Worktree on
-    // disk for the Consumer to look at (ADR 0027).
+    // After the Worktree, so that a hard stop at any earlier stage leaves it on
+    // disk for the Consumer to look at (ADR 0027) — and because a Branch cannot
+    // be deleted while a Worktree still has it checked out.
     try {
       await removeTicketWorktree(cwd, worktree);
+      tip = await collectOntoRunBranch(cwd, {
+        runBranch,
+        branch,
+        base: tip,
+        message: mergeMessage(ticket),
+      });
     } catch (error) {
       return hardStop(
         stdout,

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -4,7 +4,7 @@ import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { test } from "node:test";
 import { promisify } from "node:util";
-import { createTicketWorktree, headCommit, originRepository, WorktreeExistsError, WorktreeInstallError } from "../src/git.ts";
+import { collectOntoRunBranch, createTicketWorktree, headCommit, originRepository, WorktreeExistsError, WorktreeInstallError } from "../src/git.ts";
 import { commitMismatchedNpmLockfile, commitNpmConsumer, commitRepoFiles, throwawayRepo } from "./throwaway-repo.ts";
 
 const exec = promisify(execFile);
@@ -248,6 +248,28 @@ test("createTicketWorktree fails with the install command's output when install 
         return true;
       },
     );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("collectOntoRunBranch leaves no Run Branch behind when it cannot merge the Ticket's Branch", async () => {
+  const repo = await throwawayRepo();
+  try {
+    await assert.rejects(collectOntoRunBranch(repo.cwd, {
+      runBranch: "readyrun/run-20260902-193300",
+      branch: "readyrun/52",
+      base: await headCommit(repo.cwd),
+      message: "Ticket 52: Fix the thing",
+    }));
+
+    await assert.rejects(exec("git", [
+      "-C",
+      repo.cwd,
+      "rev-parse",
+      "--verify",
+      "refs/heads/readyrun/run-20260902-193300",
+    ]));
   } finally {
     await repo.cleanup();
   }

--- a/test/run-branch.test.ts
+++ b/test/run-branch.test.ts
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { access } from "node:fs/promises";
+import { join } from "node:path";
+import { test } from "node:test";
+import { defineConfig, run } from "../src/mod.ts";
+import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
+import { createWorkerAdapter } from "../src/worker-adapter.ts";
+import { ticket } from "./tracker-adapter-contract.ts";
+import {
+  commitWorkerWork,
+  git,
+  runBranches,
+  throwawayRepo,
+} from "./throwaway-repo.ts";
+
+const silent = { write(_chunk?: string) { return true; } };
+
+async function onDisk(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test("a Run that lands a Ticket collects it onto one Run Branch cut from the base, and deletes the Ticket's Branch", async () => {
+  const repo = await throwawayRepo();
+  try {
+    const base = await git(repo.cwd, ["rev-parse", "HEAD"]);
+
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "52", title: "Fix the thing" })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(exitCode, 0);
+    const branches = await runBranches(repo.cwd);
+    assert.equal(branches.length, 1);
+    const runBranch = branches[0] ?? "";
+    assert.match(runBranch, /^readyrun\/run-\d{8}-\d{6}$/);
+    assert.equal(
+      await git(repo.cwd, [
+        "rev-list",
+        "--first-parent",
+        "--count",
+        `${base}..${runBranch}`,
+      ]),
+      "1",
+    );
+    assert.equal(await git(repo.cwd, ["rev-parse", `${runBranch}^1`]), base);
+    assert.equal(
+      await git(repo.cwd, ["log", "-1", "--format=%s", runBranch]),
+      "Ticket 52: Fix the thing",
+    );
+    assert.equal(
+      await git(repo.cwd, ["log", "-1", "--format=%s", `${runBranch}^2`]),
+      "Ticket 52",
+    );
+    await assert.rejects(
+      git(repo.cwd, ["rev-parse", "--verify", "refs/heads/readyrun/52"]),
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("each Ticket of a Run is one entry on the Run Branch, and the next Ticket starts from a tree holding the work of the ones before it", async () => {
+  const repo = await throwawayRepo();
+  const sawTicket52WorkAtSpawn: Record<string, boolean> = {};
+  const worker = createWorkerAdapter({
+    async spawn(request) {
+      sawTicket52WorkAtSpawn[request.ticket.id] = await onDisk(
+        join(request.cwd, "ticket-52.txt"),
+      );
+      await commitWorkerWork(request);
+      return { exitCode: 0 };
+    },
+  });
+  try {
+    const base = await git(repo.cwd, ["rev-parse", "HEAD"]);
+
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [
+            ticket({ id: "52", title: "Fix the thing" }),
+            ticket({ id: "57", title: "Fix the other thing" }),
+          ],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(sawTicket52WorkAtSpawn, { 52: false, 57: true });
+    const runBranch = (await runBranches(repo.cwd))[0] ?? "";
+    assert.deepEqual(
+      (await git(repo.cwd, [
+        "log",
+        "--first-parent",
+        "--format=%s",
+        `${base}..${runBranch}`,
+      ])).split("\n"),
+      ["Ticket 57: Fix the other thing", "Ticket 52: Fix the thing"],
+    );
+    for (const id of ["52", "57"]) {
+      await assert.rejects(
+        git(repo.cwd, ["rev-parse", "--verify", `refs/heads/readyrun/${id}`]),
+      );
+    }
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a Run over an empty Frontier leaves no Run Branch behind", async () => {
+  const repo = await throwawayRepo();
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "99", labels: ["other"] })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cap: 3,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(await runBranches(repo.cwd), []);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a Run that hard-stops on its first Ticket leaves no Run Branch behind", async () => {
+  const repo = await throwawayRepo();
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "52" }), ticket({ id: "57" })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker: recordingWorker({ exitCode: 42 }),
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(await runBranches(repo.cwd), []);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a Run that hard-stops on a later Ticket leaves the Run Branch holding the Tickets that already landed", async () => {
+  const repo = await throwawayRepo();
+  const worker = createWorkerAdapter({
+    async spawn(request) {
+      if (request.ticket.id === "57") {
+        return { exitCode: 42 };
+      }
+      await commitWorkerWork(request);
+      return { exitCode: 0 };
+    },
+  });
+  try {
+    const base = await git(repo.cwd, ["rev-parse", "HEAD"]);
+
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [
+            ticket({ id: "52", title: "Fix the thing" }),
+            ticket({ id: "57", title: "Fix the other thing" }),
+          ],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(exitCode, 1);
+    const runBranch = (await runBranches(repo.cwd))[0] ?? "";
+    assert.deepEqual(
+      (await git(repo.cwd, [
+        "log",
+        "--first-parent",
+        "--format=%s",
+        `${base}..${runBranch}`,
+      ])).split("\n"),
+      ["Ticket 52: Fix the thing"],
+    );
+    await git(repo.cwd, ["rev-parse", "--verify", "refs/heads/readyrun/57"]);
+  } finally {
+    await repo.cleanup();
+  }
+});

--- a/test/run-branch.test.ts
+++ b/test/run-branch.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { access } from "node:fs/promises";
 import { join } from "node:path";
 import { test } from "node:test";
 import { defineConfig, run } from "../src/mod.ts";
@@ -7,25 +6,27 @@ import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
 import { createWorkerAdapter } from "../src/worker-adapter.ts";
 import { ticket } from "./tracker-adapter-contract.ts";
 import {
+  commitRepoFiles,
   commitWorkerWork,
   git,
+  onDisk,
+  runBranch,
+  runBranchMerges,
   runBranches,
   throwawayRepo,
 } from "./throwaway-repo.ts";
 
 const silent = { write(_chunk?: string) { return true; } };
 
-async function onDisk(path: string): Promise<boolean> {
-  try {
-    await access(path);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-test("a Run that lands a Ticket collects it onto one Run Branch cut from the base, and deletes the Ticket's Branch", async () => {
+test("a Run that lands a Ticket collects it onto one Run Branch cut from the base, keeping the Worker's own commits under one merge", async () => {
   const repo = await throwawayRepo();
+  const worker = createWorkerAdapter({
+    async spawn(request) {
+      await commitRepoFiles(request.cwd, { "first.txt": "one\n" }, "First");
+      await commitRepoFiles(request.cwd, { "second.txt": "two\n" }, "Second");
+      return { exitCode: 0 };
+    },
+  });
   try {
     const base = await git(repo.cwd, ["rev-parse", "HEAD"]);
 
@@ -36,7 +37,7 @@ test("a Run that lands a Ticket collects it onto one Run Branch cut from the bas
           ready: "unblocked",
           labels: ["ready-for-agent"],
         }),
-        worker: recordingWorker({ exitCode: 0 }),
+        worker,
         model: "composer-2",
       }),
       cap: 1,
@@ -45,27 +46,16 @@ test("a Run that lands a Ticket collects it onto one Run Branch cut from the bas
     });
 
     assert.equal(exitCode, 0);
-    const branches = await runBranches(repo.cwd);
-    assert.equal(branches.length, 1);
-    const runBranch = branches[0] ?? "";
-    assert.match(runBranch, /^readyrun\/run-\d{8}-\d{6}$/);
-    assert.equal(
-      await git(repo.cwd, [
-        "rev-list",
-        "--first-parent",
-        "--count",
-        `${base}..${runBranch}`,
-      ]),
-      "1",
-    );
-    assert.equal(await git(repo.cwd, ["rev-parse", `${runBranch}^1`]), base);
-    assert.equal(
-      await git(repo.cwd, ["log", "-1", "--format=%s", runBranch]),
+    const collected = await runBranch(repo.cwd);
+    assert.match(collected, /^readyrun\/run-\d{8}-\d{6}$/);
+    assert.deepEqual(await runBranchMerges(repo.cwd, base), [
       "Ticket 52: Fix the thing",
-    );
-    assert.equal(
-      await git(repo.cwd, ["log", "-1", "--format=%s", `${runBranch}^2`]),
-      "Ticket 52",
+    ]);
+    assert.equal(await git(repo.cwd, ["rev-parse", `${collected}^1`]), base);
+    assert.deepEqual(
+      (await git(repo.cwd, ["log", "--format=%s", `${base}..${collected}^2`]))
+        .split("\n"),
+      ["Second", "First"],
     );
     await assert.rejects(
       git(repo.cwd, ["rev-parse", "--verify", "refs/heads/readyrun/52"]),
@@ -110,16 +100,10 @@ test("each Ticket of a Run is one entry on the Run Branch, and the next Ticket s
 
     assert.equal(exitCode, 0);
     assert.deepEqual(sawTicket52WorkAtSpawn, { 52: false, 57: true });
-    const runBranch = (await runBranches(repo.cwd))[0] ?? "";
-    assert.deepEqual(
-      (await git(repo.cwd, [
-        "log",
-        "--first-parent",
-        "--format=%s",
-        `${base}..${runBranch}`,
-      ])).split("\n"),
-      ["Ticket 57: Fix the other thing", "Ticket 52: Fix the thing"],
-    );
+    assert.deepEqual(await runBranchMerges(repo.cwd, base), [
+      "Ticket 57: Fix the other thing",
+      "Ticket 52: Fix the thing",
+    ]);
     for (const id of ["52", "57"]) {
       await assert.rejects(
         git(repo.cwd, ["rev-parse", "--verify", `refs/heads/readyrun/${id}`]),
@@ -213,16 +197,9 @@ test("a Run that hard-stops on a later Ticket leaves the Run Branch holding the 
     });
 
     assert.equal(exitCode, 1);
-    const runBranch = (await runBranches(repo.cwd))[0] ?? "";
-    assert.deepEqual(
-      (await git(repo.cwd, [
-        "log",
-        "--first-parent",
-        "--format=%s",
-        `${base}..${runBranch}`,
-      ])).split("\n"),
-      ["Ticket 52: Fix the thing"],
-    );
+    assert.deepEqual(await runBranchMerges(repo.cwd, base), [
+      "Ticket 52: Fix the thing",
+    ]);
     await git(repo.cwd, ["rev-parse", "--verify", "refs/heads/readyrun/57"]);
   } finally {
     await repo.cleanup();

--- a/test/run-frontier.test.ts
+++ b/test/run-frontier.test.ts
@@ -239,8 +239,6 @@ test("a v0 Run starts one Worker at a time; each Ticket still gets its own Branc
     });
 
     assert.equal(maxInFlight, 1);
-    await git(repo.cwd, ["rev-parse", "--verify", "refs/heads/readyrun/52"]);
-    await git(repo.cwd, ["rev-parse", "--verify", "refs/heads/readyrun/57"]);
     assert.match(worktreesAtSpawn["52"] ?? "", /readyrun\/52/);
     assert.match(worktreesAtSpawn["57"] ?? "", /readyrun\/57/);
     assert.equal(await git(repo.cwd, ["rev-parse", "--abbrev-ref", "HEAD"]), "main");

--- a/test/run-one-ticket.test.ts
+++ b/test/run-one-ticket.test.ts
@@ -74,6 +74,14 @@ test("a Run with cap 1 against one unblocked Ticket starts exactly one Worker wi
 
 test("ReadyRun creates a Branch derived from the Ticket's identity; the Ticket body does not name the Branch", async () => {
   const repo = await throwawayRepo();
+  let branchAtSpawn: string | undefined;
+  const worker = createWorkerAdapter({
+    async spawn(request) {
+      branchAtSpawn = await git(request.cwd, ["branch", "--show-current"]);
+      await commitWorkerWork(request);
+      return { exitCode: 0 };
+    },
+  });
   try {
     await run({
       config: defineConfig({
@@ -82,7 +90,7 @@ test("ReadyRun creates a Branch derived from the Ticket's identity; the Ticket b
           ready: "unblocked",
           labels: ["ready-for-agent"],
         }),
-        worker: recordingWorker({ exitCode: 0 }),
+        worker,
         model: "composer-2",
       }),
       cap: 1,
@@ -90,7 +98,7 @@ test("ReadyRun creates a Branch derived from the Ticket's identity; the Ticket b
       stdout: silent,
     });
 
-    await git(repo.cwd, ["rev-parse", "--verify", "refs/heads/readyrun/52"]);
+    assert.equal(branchAtSpawn, "readyrun/52");
     await assert.rejects(() =>
       git(repo.cwd, ["rev-parse", "--verify", "refs/heads/evil-from-body"]),
     );

--- a/test/run-ticket-base.test.ts
+++ b/test/run-ticket-base.test.ts
@@ -8,7 +8,8 @@ import {
   commitRepoFiles,
   commitWorkerWork,
   git,
-  runBranches,
+  runBranch,
+  runBranchMerges,
   throwawayRepo,
 } from "./throwaway-repo.ts";
 
@@ -45,20 +46,12 @@ test("a Run builds on the base it resolved at start, and not on the Consumer's c
 
     const moved = await git(repo.cwd, ["rev-parse", "HEAD"]);
     assert.notEqual(moved, base);
-    const runBranch = (await runBranches(repo.cwd))[0] ?? "";
-    await git(repo.cwd, ["merge-base", "--is-ancestor", base, runBranch]);
+    const collected = await runBranch(repo.cwd);
+    await git(repo.cwd, ["merge-base", "--is-ancestor", base, collected]);
     await assert.rejects(
-      git(repo.cwd, ["merge-base", "--is-ancestor", moved, runBranch]),
+      git(repo.cwd, ["merge-base", "--is-ancestor", moved, collected]),
     );
-    assert.equal(
-      await git(repo.cwd, [
-        "rev-list",
-        "--first-parent",
-        "--count",
-        `${base}..${runBranch}`,
-      ]),
-      "2",
-    );
+    assert.equal((await runBranchMerges(repo.cwd, base)).length, 2);
   } finally {
     await repo.cleanup();
   }

--- a/test/run-ticket-base.test.ts
+++ b/test/run-ticket-base.test.ts
@@ -8,12 +8,13 @@ import {
   commitRepoFiles,
   commitWorkerWork,
   git,
+  runBranches,
   throwawayRepo,
 } from "./throwaway-repo.ts";
 
 const silent = { write(_chunk?: string) { return true; } };
 
-test("every Ticket in a Run branches from the base the Run resolved at start, even when the Consumer's checkout moves mid-Run", async () => {
+test("a Run builds on the base it resolved at start, and not on the Consumer's checkout as that moves mid-Run", async () => {
   const repo = await throwawayRepo();
   const worker = createWorkerAdapter({
     async spawn(request) {
@@ -42,9 +43,22 @@ test("every Ticket in a Run branches from the base the Run resolved at start, ev
       stdout: silent,
     });
 
-    assert.notEqual(await git(repo.cwd, ["rev-parse", "HEAD"]), base);
-    assert.equal(await git(repo.cwd, ["rev-parse", "readyrun/52^"]), base);
-    assert.equal(await git(repo.cwd, ["rev-parse", "readyrun/57^"]), base);
+    const moved = await git(repo.cwd, ["rev-parse", "HEAD"]);
+    assert.notEqual(moved, base);
+    const runBranch = (await runBranches(repo.cwd))[0] ?? "";
+    await git(repo.cwd, ["merge-base", "--is-ancestor", base, runBranch]);
+    await assert.rejects(
+      git(repo.cwd, ["merge-base", "--is-ancestor", moved, runBranch]),
+    );
+    assert.equal(
+      await git(repo.cwd, [
+        "rev-list",
+        "--first-parent",
+        "--count",
+        `${base}..${runBranch}`,
+      ]),
+      "2",
+    );
   } finally {
     await repo.cleanup();
   }

--- a/test/run-worker-commit.test.ts
+++ b/test/run-worker-commit.test.ts
@@ -6,7 +6,7 @@ import { defineConfig, run } from "../src/mod.ts";
 import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
 import { createWorkerAdapter } from "../src/worker-adapter.ts";
 import { ticket } from "./tracker-adapter-contract.ts";
-import { git, runBranches, throwawayRepo } from "./throwaway-repo.ts";
+import { git, runBranchMerges, throwawayRepo } from "./throwaway-repo.ts";
 
 const silent = { write(_chunk?: string) { return true; } };
 
@@ -104,16 +104,7 @@ test("a Worker exiting 0 with a clean Worktree and a commit on its Branch takes 
     assert.equal(exitCode, 0);
     assert.deepEqual(worker.spawns.map((spawn) => spawn.ticket.id), ["52", "57"]);
     assert.deepEqual(await frontier.frontier(), []);
-    const runBranch = (await runBranches(repo.cwd))[0] ?? "";
-    assert.equal(
-      await git(repo.cwd, [
-        "rev-list",
-        "--first-parent",
-        "--count",
-        `${base}..${runBranch}`,
-      ]),
-      "2",
-    );
+    assert.equal((await runBranchMerges(repo.cwd, base)).length, 2);
   } finally {
     await repo.cleanup();
   }

--- a/test/run-worker-commit.test.ts
+++ b/test/run-worker-commit.test.ts
@@ -6,7 +6,7 @@ import { defineConfig, run } from "../src/mod.ts";
 import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
 import { createWorkerAdapter } from "../src/worker-adapter.ts";
 import { ticket } from "./tracker-adapter-contract.ts";
-import { git, throwawayRepo } from "./throwaway-repo.ts";
+import { git, runBranches, throwawayRepo } from "./throwaway-repo.ts";
 
 const silent = { write(_chunk?: string) { return true; } };
 
@@ -104,9 +104,15 @@ test("a Worker exiting 0 with a clean Worktree and a commit on its Branch takes 
     assert.equal(exitCode, 0);
     assert.deepEqual(worker.spawns.map((spawn) => spawn.ticket.id), ["52", "57"]);
     assert.deepEqual(await frontier.frontier(), []);
+    const runBranch = (await runBranches(repo.cwd))[0] ?? "";
     assert.equal(
-      await git(repo.cwd, ["rev-list", "--count", `${base}..readyrun/52`]),
-      "1",
+      await git(repo.cwd, [
+        "rev-list",
+        "--first-parent",
+        "--count",
+        `${base}..${runBranch}`,
+      ]),
+      "2",
     );
   } finally {
     await repo.cleanup();

--- a/test/run-worktree-lifetime.test.ts
+++ b/test/run-worktree-lifetime.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { access } from "node:fs/promises";
 import { join } from "node:path";
 import { test } from "node:test";
 import { createTrackerAdapter, defineConfig, run } from "../src/mod.ts";
@@ -9,7 +8,8 @@ import { ticket } from "./tracker-adapter-contract.ts";
 import {
   commitWorkerWork,
   git,
-  runBranches,
+  onDisk,
+  runBranchMerges,
   throwawayRepo,
 } from "./throwaway-repo.ts";
 
@@ -25,15 +25,6 @@ function tracker() {
 
 function worktreeOf(cwd: string, ticketId: string): string {
   return join(cwd, ".readyrun", "worktrees", `readyrun-${ticketId}`);
-}
-
-async function onDisk(path: string): Promise<boolean> {
-  try {
-    await access(path);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 test("a verified-successful Ticket's Worktree is gone before the next Ticket starts, and the Run Branch carries the work", async () => {
@@ -61,16 +52,7 @@ test("a verified-successful Ticket's Worktree is gone before the next Ticket sta
     assert.equal(exitCode, 0);
     assert.deepEqual(ticket52WorktreeAtSpawnOf, { 52: true, 57: false });
     assert.equal(await onDisk(worktreeOf(repo.cwd, "57")), false);
-    const runBranch = (await runBranches(repo.cwd))[0] ?? "";
-    assert.equal(
-      await git(repo.cwd, [
-        "rev-list",
-        "--first-parent",
-        "--count",
-        `${base}..${runBranch}`,
-      ]),
-      "2",
-    );
+    assert.equal((await runBranchMerges(repo.cwd, base)).length, 2);
   } finally {
     await repo.cleanup();
   }

--- a/test/run-worktree-lifetime.test.ts
+++ b/test/run-worktree-lifetime.test.ts
@@ -6,7 +6,12 @@ import { createTrackerAdapter, defineConfig, run } from "../src/mod.ts";
 import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
 import { createWorkerAdapter } from "../src/worker-adapter.ts";
 import { ticket } from "./tracker-adapter-contract.ts";
-import { commitWorkerWork, git, throwawayRepo } from "./throwaway-repo.ts";
+import {
+  commitWorkerWork,
+  git,
+  runBranches,
+  throwawayRepo,
+} from "./throwaway-repo.ts";
 
 const silent = { write(_chunk?: string) { return true; } };
 
@@ -31,7 +36,7 @@ async function onDisk(path: string): Promise<boolean> {
   }
 }
 
-test("a verified-successful Ticket's Worktree is gone before the next Ticket starts, and its Branch still carries the work", async () => {
+test("a verified-successful Ticket's Worktree is gone before the next Ticket starts, and the Run Branch carries the work", async () => {
   const repo = await throwawayRepo();
   const ticket52WorktreeAtSpawnOf: Record<string, boolean> = {};
   const worker = createWorkerAdapter({
@@ -56,13 +61,15 @@ test("a verified-successful Ticket's Worktree is gone before the next Ticket sta
     assert.equal(exitCode, 0);
     assert.deepEqual(ticket52WorktreeAtSpawnOf, { 52: true, 57: false });
     assert.equal(await onDisk(worktreeOf(repo.cwd, "57")), false);
+    const runBranch = (await runBranches(repo.cwd))[0] ?? "";
     assert.equal(
-      await git(repo.cwd, ["rev-list", "--count", `${base}..readyrun/52`]),
-      "1",
-    );
-    assert.equal(
-      await git(repo.cwd, ["rev-list", "--count", `${base}..readyrun/57`]),
-      "1",
+      await git(repo.cwd, [
+        "rev-list",
+        "--first-parent",
+        "--count",
+        `${base}..${runBranch}`,
+      ]),
+      "2",
     );
   } finally {
     await repo.cleanup();

--- a/test/throwaway-repo.ts
+++ b/test/throwaway-repo.ts
@@ -49,6 +49,15 @@ export async function throwawayRepo(options: {
   };
 }
 
+export async function runBranches(cwd: string): Promise<string[]> {
+  const refs = await git(cwd, [
+    "for-each-ref",
+    "--format=%(refname:short)",
+    "refs/heads/readyrun/run-*",
+  ]);
+  return refs.split("\n").filter(Boolean);
+}
+
 export async function commitRepoFiles(
   cwd: string,
   files: Record<string, string>,

--- a/test/throwaway-repo.ts
+++ b/test/throwaway-repo.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -49,6 +49,15 @@ export async function throwawayRepo(options: {
   };
 }
 
+export async function onDisk(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function runBranches(cwd: string): Promise<string[]> {
   const refs = await git(cwd, [
     "for-each-ref",
@@ -56,6 +65,33 @@ export async function runBranches(cwd: string): Promise<string[]> {
     "refs/heads/readyrun/run-*",
   ]);
   return refs.split("\n").filter(Boolean);
+}
+
+// A Run has exactly one Run Branch, so a test that asks for it means that one.
+export async function runBranch(cwd: string): Promise<string> {
+  const branches = await runBranches(cwd);
+  const only = branches[0];
+  if (only === undefined || branches.length > 1) {
+    throw new Error(
+      `expected one Run Branch, found ${branches.join(", ") || "none"}`,
+    );
+  }
+  return only;
+}
+
+// The subjects of the Run Branch's first-parent history: one per Ticket the
+// Run landed, most recent first.
+export async function runBranchMerges(
+  cwd: string,
+  base: string,
+): Promise<string[]> {
+  const log = await git(cwd, [
+    "log",
+    "--first-parent",
+    "--format=%s",
+    `${base}..${await runBranch(cwd)}`,
+  ]);
+  return log.split("\n").filter(Boolean);
 }
 
 export async function commitRepoFiles(


### PR DESCRIPTION
## Why

A Run of ten Tickets left ten Branches to merge by hand, which is precisely the human-in-the-loop cost this product exists to delete. ADR 0028: a Run has exactly one Run Branch and leaves one thing to review, with each Ticket still working on its own Branch because two Workers cannot share one.

Each Ticket also had to start from a tree containing what the Run had already finished, which a per-Ticket Branch cut from a fixed base could not give.

## What

A Run names a Run Branch `readyrun/run-<YYYYMMDD-HHMMSS>` at start but writes no ref until a Ticket lands, so a Run that lands nothing leaves nothing behind. A verified-successful Ticket's Branch is merged in as one two-parent commit and deleted, and the next Ticket's Branch is cut from the new tip. One Ticket is one entry in the Run Branch's first-parent history with the Worker's own commits underneath; a hard stop leaves the Run Branch holding whatever already landed.

## How

The merge is made with plumbing — `merge-tree --write-tree`, `commit-tree`, `update-ref` — rather than `git merge`, which would need a working tree: either the Consumer's checkout, which is theirs and which a Run already promises never to move, or a scratch Worktree checked out per Ticket. The shape is identical: two parents, never squashed, never fast-forwarded. The ref is written by the same `update-ref` that lands the merge, so a first Ticket that fails to merge leaves no Run Branch either. Deleting the Branch needs `--force` because git measures merged-ness against the Consumer's HEAD, not the Run Branch.

The merge message is `Ticket <id>: <title>`, copied from the Ticket the way the Branch name is derived from it — still the only commit ReadyRun writes.

Five existing tests asserted a Ticket's Branch survives its Run, which is exactly what ADR 0028 changes. Each now asserts its original promise in the new terms: the Branch checked out at spawn, or the Run Branch's history.

## Workarounds

The Worktree is removed before the merge, per this issue's ordering and #74's constraint that a Branch cannot be deleted while a Worktree has it checked out. A merge that failed would therefore hard-stop with the Worktree already gone, against ADR 0027's keep-on-failure — accepted because ADR 0028 establishes serial Runs cannot conflict, and the Ticket's Branch, which carries the work, is kept.

Two Runs started in the same repo in the same second would share a Run Branch. Detecting that needs the Run to remember it created the ref, which neither the issue nor the ADR asks for.

Closes #75

Made with [Cursor](https://cursor.com)