### PR TITLE
Name the cause and next action on Consumer-facing failures (#62)

### DIFF
--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -131,7 +131,7 @@ export function github(
       if (fromGh !== undefined && fromGh.length > 0) {
         return fromGh;
       }
-      throw githubAuthFailure();
+      throw new GitHubAuthError();
     }
     const env = runtime.env ?? process.env;
     const fromEnv = firstNonEmpty(env.GH_TOKEN, env.GITHUB_TOKEN);
@@ -142,7 +142,7 @@ export function github(
     if (fromGh !== undefined && fromGh.length > 0) {
       return fromGh;
     }
-    throw githubAuthFailure();
+    throw new GitHubAuthError();
   }
 
   async function graphql<T>(
@@ -163,19 +163,17 @@ export function github(
         error instanceof Error &&
         /could not resolve to a repository/i.test(error.message)
       ) {
-        throw new Error(
-          `this token cannot see GitHub repository ${options.repo}. Check the token's access to that repository.`,
-        );
+        throw new GitHubCannotSeeError(options.repo);
       }
       if (
-        error instanceof Error &&
-        (error.message.startsWith("ReadyRun ") ||
-          error.message.startsWith("this token cannot see "))
+        error instanceof GitHubUnreachableError ||
+        error instanceof GitHubAuthError ||
+        error instanceof GitHubCannotSeeError
       ) {
         throw error;
       }
       const vendor = error instanceof Error ? error.message : String(error);
-      throw githubUnreachable(vendor);
+      throw new GitHubUnreachableError(vendor);
     }
   }
 
@@ -361,16 +359,31 @@ const githubHeaders = (token: string): Record<string, string> => ({
   "X-GitHub-Api-Version": "2022-11-28",
 });
 
-function githubUnreachable(vendor: string): Error {
-  return new Error(
-    `ReadyRun could not reach GitHub. Check Tracker auth and network. ${vendor}`,
-  );
+class GitHubUnreachableError extends Error {
+  constructor(vendor: string) {
+    super(
+      `ReadyRun could not reach GitHub. Check Tracker auth and network. ${vendor}`,
+    );
+    this.name = "GitHubUnreachableError";
+  }
 }
 
-function githubAuthFailure(): Error {
-  return new Error(
-    "ReadyRun could not authenticate to GitHub. Check the GitHub token.",
-  );
+class GitHubAuthError extends Error {
+  constructor() {
+    super(
+      "ReadyRun could not authenticate to GitHub. Check the GitHub token.",
+    );
+    this.name = "GitHubAuthError";
+  }
+}
+
+class GitHubCannotSeeError extends Error {
+  constructor(repo: string) {
+    super(
+      `this token cannot see GitHub repository ${repo}. Check the token's access to that repository.`,
+    );
+    this.name = "GitHubCannotSeeError";
+  }
 }
 
 async function githubGraphql<T>(
@@ -391,15 +404,15 @@ async function githubGraphql<T>(
   };
   if (!response.ok) {
     if (response.status === 401) {
-      throw githubAuthFailure();
+      throw new GitHubAuthError();
     }
-    throw githubUnreachable(`GitHub GraphQL HTTP ${response.status}`);
+    throw new GitHubUnreachableError(`GitHub GraphQL HTTP ${response.status}`);
   }
   if (payload.errors !== undefined && payload.errors.length > 0) {
     throw new Error(payload.errors[0]?.message ?? "GitHub GraphQL error");
   }
   if (payload.data === undefined) {
-    throw githubUnreachable("GitHub GraphQL returned no data");
+    throw new GitHubUnreachableError("GitHub GraphQL returned no data");
   }
   return payload.data;
 }
@@ -418,9 +431,9 @@ async function githubRest(
   });
   if (!response.ok) {
     if (response.status === 401) {
-      throw githubAuthFailure();
+      throw new GitHubAuthError();
     }
-    throw githubUnreachable(`GitHub REST HTTP ${response.status}`);
+    throw new GitHubUnreachableError(`GitHub REST HTTP ${response.status}`);
   }
 }
 

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -131,7 +131,7 @@ export function github(
       if (fromGh !== undefined && fromGh.length > 0) {
         return fromGh;
       }
-      throw new Error("ReadyRun could not authenticate to GitHub");
+      throw githubAuthFailure();
     }
     const env = runtime.env ?? process.env;
     const fromEnv = firstNonEmpty(env.GH_TOKEN, env.GITHUB_TOKEN);
@@ -142,7 +142,7 @@ export function github(
     if (fromGh !== undefined && fromGh.length > 0) {
       return fromGh;
     }
-    throw new Error("ReadyRun could not authenticate to GitHub");
+    throw githubAuthFailure();
   }
 
   async function graphql<T>(
@@ -164,10 +164,18 @@ export function github(
         /could not resolve to a repository/i.test(error.message)
       ) {
         throw new Error(
-          `this token cannot see GitHub repository ${options.repo}`,
+          `this token cannot see GitHub repository ${options.repo}. Check the token's access to that repository.`,
         );
       }
-      throw error;
+      if (
+        error instanceof Error &&
+        (error.message.startsWith("ReadyRun ") ||
+          error.message.startsWith("this token cannot see "))
+      ) {
+        throw error;
+      }
+      const vendor = error instanceof Error ? error.message : String(error);
+      throw githubUnreachable(vendor);
     }
   }
 
@@ -353,6 +361,18 @@ const githubHeaders = (token: string): Record<string, string> => ({
   "X-GitHub-Api-Version": "2022-11-28",
 });
 
+function githubUnreachable(vendor: string): Error {
+  return new Error(
+    `ReadyRun could not reach GitHub. Check Tracker auth and network. ${vendor}`,
+  );
+}
+
+function githubAuthFailure(): Error {
+  return new Error(
+    "ReadyRun could not authenticate to GitHub. Check the GitHub token.",
+  );
+}
+
 async function githubGraphql<T>(
   http: typeof fetch,
   token: string,
@@ -370,13 +390,16 @@ async function githubGraphql<T>(
     errors?: { message: string }[];
   };
   if (!response.ok) {
-    throw new Error(`GitHub GraphQL HTTP ${response.status}`);
+    if (response.status === 401) {
+      throw githubAuthFailure();
+    }
+    throw githubUnreachable(`GitHub GraphQL HTTP ${response.status}`);
   }
   if (payload.errors !== undefined && payload.errors.length > 0) {
     throw new Error(payload.errors[0]?.message ?? "GitHub GraphQL error");
   }
   if (payload.data === undefined) {
-    throw new Error("GitHub GraphQL returned no data");
+    throw githubUnreachable("GitHub GraphQL returned no data");
   }
   return payload.data;
 }
@@ -394,7 +417,10 @@ async function githubRest(
     body: body === undefined ? undefined : JSON.stringify(body),
   });
   if (!response.ok) {
-    throw new Error(`GitHub REST HTTP ${response.status}`);
+    if (response.status === 401) {
+      throw githubAuthFailure();
+    }
+    throw githubUnreachable(`GitHub REST HTTP ${response.status}`);
   }
 }
 

--- a/src/adapters/linear.ts
+++ b/src/adapters/linear.ts
@@ -184,7 +184,7 @@ export function linear(
     if (fromEnv !== undefined && fromEnv.length > 0) {
       return fromEnv;
     }
-    throw new Error("ReadyRun could not authenticate to Linear");
+    throw linearAuthFailure();
   }
 
   async function graphql<T>(
@@ -384,6 +384,18 @@ function names(nodes: (LabelNode | null)[]): string[] {
   return nodes.flatMap((node) => node === null ? [] : [node.name]);
 }
 
+function linearUnreachable(vendor: string): Error {
+  return new Error(
+    `ReadyRun could not reach Linear. Check Tracker auth and network. ${vendor}`,
+  );
+}
+
+function linearAuthFailure(): Error {
+  return new Error(
+    "ReadyRun could not authenticate to Linear. Check the Linear token.",
+  );
+}
+
 async function linearGraphql<T>(
   http: typeof fetch,
   token: string,
@@ -405,15 +417,15 @@ async function linearGraphql<T>(
   };
   if (!response.ok) {
     if (response.status === 401) {
-      throw new Error("ReadyRun could not authenticate to Linear");
+      throw linearAuthFailure();
     }
-    throw new Error(`Linear GraphQL HTTP ${response.status}`);
+    throw linearUnreachable(`Linear GraphQL HTTP ${response.status}`);
   }
   if (payload.errors !== undefined && payload.errors.length > 0) {
-    throw new Error(payload.errors[0]?.message ?? "Linear GraphQL error");
+    throw linearUnreachable(payload.errors[0]?.message ?? "Linear GraphQL error");
   }
   if (payload.data === undefined) {
-    throw new Error("Linear GraphQL returned no data");
+    throw linearUnreachable("Linear GraphQL returned no data");
   }
   return payload.data;
 }

--- a/src/adapters/linear.ts
+++ b/src/adapters/linear.ts
@@ -184,7 +184,7 @@ export function linear(
     if (fromEnv !== undefined && fromEnv.length > 0) {
       return fromEnv;
     }
-    throw linearAuthFailure();
+    throw new LinearAuthError();
   }
 
   async function graphql<T>(
@@ -192,7 +192,24 @@ export function linear(
     query: string,
     variables: Record<string, unknown> = {},
   ): Promise<T> {
-    return linearGraphql<T>(http, await token(), operationName, query, variables);
+    try {
+      return await linearGraphql<T>(
+        http,
+        await token(),
+        operationName,
+        query,
+        variables,
+      );
+    } catch (error) {
+      if (
+        error instanceof LinearUnreachableError ||
+        error instanceof LinearAuthError
+      ) {
+        throw error;
+      }
+      const vendor = error instanceof Error ? error.message : String(error);
+      throw new LinearUnreachableError(vendor);
+    }
   }
 
   async function canExpressBlocking(): Promise<boolean> {
@@ -384,16 +401,22 @@ function names(nodes: (LabelNode | null)[]): string[] {
   return nodes.flatMap((node) => node === null ? [] : [node.name]);
 }
 
-function linearUnreachable(vendor: string): Error {
-  return new Error(
-    `ReadyRun could not reach Linear. Check Tracker auth and network. ${vendor}`,
-  );
+class LinearUnreachableError extends Error {
+  constructor(vendor: string) {
+    super(
+      `ReadyRun could not reach Linear. Check Tracker auth and network. ${vendor}`,
+    );
+    this.name = "LinearUnreachableError";
+  }
 }
 
-function linearAuthFailure(): Error {
-  return new Error(
-    "ReadyRun could not authenticate to Linear. Check the Linear token.",
-  );
+class LinearAuthError extends Error {
+  constructor() {
+    super(
+      "ReadyRun could not authenticate to Linear. Check the Linear token.",
+    );
+    this.name = "LinearAuthError";
+  }
 }
 
 async function linearGraphql<T>(
@@ -417,15 +440,15 @@ async function linearGraphql<T>(
   };
   if (!response.ok) {
     if (response.status === 401) {
-      throw linearAuthFailure();
+      throw new LinearAuthError();
     }
-    throw linearUnreachable(`Linear GraphQL HTTP ${response.status}`);
+    throw new LinearUnreachableError(`Linear GraphQL HTTP ${response.status}`);
   }
   if (payload.errors !== undefined && payload.errors.length > 0) {
-    throw linearUnreachable(payload.errors[0]?.message ?? "Linear GraphQL error");
+    throw new LinearUnreachableError(payload.errors[0]?.message ?? "Linear GraphQL error");
   }
   if (payload.data === undefined) {
-    throw linearUnreachable("Linear GraphQL returned no data");
+    throw new LinearUnreachableError("Linear GraphQL returned no data");
   }
   return payload.data;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ const configNames = [
 export class ConfigNotFoundError extends Error {
   constructor() {
     super(
-      "No readyrun.config.ts, readyrun.config.js, or readyrun.config.mjs at the Consumer root",
+      "No readyrun.config.ts, readyrun.config.js, or readyrun.config.mjs at the Consumer root. Run `readyrun init`.",
     );
     this.name = "ConfigNotFoundError";
   }
@@ -38,16 +38,32 @@ export class ConfigNotFoundError extends Error {
 
 export class AmbiguousConfigError extends Error {
   constructor(names: readonly string[]) {
-    super(`Multiple config files at the Consumer root: ${names.join(", ")}`);
+    super(
+      `Multiple config files at the Consumer root: ${names.join(", ")}. Leave one file.`,
+    );
     this.name = "AmbiguousConfigError";
   }
 }
 
 export class ConfigExportError extends Error {
   constructor(name: string) {
-    super(`${name} must default-export defineConfig(...)`);
+    super(
+      `${name} must default-export defineConfig(...). Default-export defineConfig(...) from that file.`,
+    );
     this.name = "ConfigExportError";
   }
+}
+
+function configLoadFailure(error: unknown): string {
+  if (
+    error instanceof ConfigNotFoundError ||
+    error instanceof AmbiguousConfigError ||
+    error instanceof ConfigExportError
+  ) {
+    return error.message;
+  }
+  const detail = error instanceof Error ? error.message : String(error);
+  return `Could not load the ReadyRun config. Fix the config file. ${detail}`;
 }
 
 export async function loadConfig(cwd: string): Promise<ReadyRunConfig> {
@@ -211,7 +227,7 @@ export async function cli(options: CliOptions): Promise<number> {
   try {
     config = await (options.loadConfig ?? loadConfig)(cwd);
   } catch (error) {
-    stdout.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    stdout.write(`${configLoadFailure(error)}\n`);
     return 1;
   }
   if (runFlags !== undefined) {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -27,7 +27,7 @@ async function check(
 ): Promise<string[]> {
   const failures: string[] = [];
   if (typeof config.model !== "string" || config.model.length === 0) {
-    failures.push("missing model default");
+    failures.push("missing model default. Set model in config or pass --model.");
   }
   let inspect;
   try {
@@ -38,21 +38,25 @@ async function check(
   }
   for (const label of inspect.selectorLabels) {
     if (!inspect.existingLabels.includes(label)) {
-      failures.push(`label "${label}" does not exist on the Tracker`);
+      failures.push(
+        `label "${label}" does not exist on the Tracker. Check the Frontier selector.`,
+      );
     }
   }
   if (
     inspect.selectorState !== undefined &&
     !(inspect.existingStates ?? []).includes(inspect.selectorState)
   ) {
-    failures.push(`state "${inspect.selectorState}" does not exist on the Tracker`);
+    failures.push(
+      `state "${inspect.selectorState}" does not exist on the Tracker. Check the Frontier selector.`,
+    );
   }
   if (
     inspect.selectorProject !== undefined &&
     !(inspect.existingProjects ?? []).includes(inspect.selectorProject)
   ) {
     failures.push(
-      `project "${inspect.selectorProject}" does not exist on the Tracker`,
+      `project "${inspect.selectorProject}" does not exist on the Tracker. Check the Frontier selector.`,
     );
   }
   if (inspect.repository !== undefined) {
@@ -62,17 +66,19 @@ async function check(
       normalizeRepository(remote) !== normalizeRepository(inspect.repository)
     ) {
       failures.push(
-        `configured repository ${inspect.repository} is not the git remote (${remote ?? "none"})`,
+        `configured repository ${inspect.repository} is not the git remote (${remote ?? "none"}). Point the Tracker at this checkout's origin.`,
       );
     }
   }
   if (!inspect.canExpressBlocking) {
     failures.push(
-      "Tracker cannot express blocking; unblocked ordering is a lie",
+      "Tracker cannot express blocking; unblocked ordering is a lie. Use a Tracker that can express blocking.",
     );
   }
   if (config.worker.bin !== undefined && !workerBinaryExists(config.worker.bin)) {
-    failures.push(`Worker binary "${config.worker.bin}" is missing`);
+    failures.push(
+      `Worker binary "${config.worker.bin}" is missing. Install it or fix worker.bin.`,
+    );
   } else if (config.worker.probe !== undefined) {
     const probeResult = await config.worker.probe();
     if (!probeResult.ok) {
@@ -80,7 +86,9 @@ async function check(
     }
   }
   if (effort !== undefined && config.worker.effortFlag === undefined) {
-    failures.push("effort is set but this Worker Adapter does not map it");
+    failures.push(
+      "effort is set but this Worker Adapter does not map it. Unset effort or pick a Worker Adapter that maps it.",
+    );
   }
   if (config.worker.printMode === true && permissions === "ask") {
     failures.push(

--- a/src/git.ts
+++ b/src/git.ts
@@ -15,7 +15,7 @@ export class DefaultBranchError extends Error {
 export class WorktreeExistsError extends Error {
   constructor(branch: string, worktreePath: string) {
     super(
-      `ReadyRun already has a Worktree for branch ${branch} at ${worktreePath}`,
+      `ReadyRun already has a Worktree for branch ${branch} at ${worktreePath}. Discard it with \`git worktree remove ${worktreePath}\` and \`git branch -D ${branch}\`, then start a new Run.`,
     );
     this.name = "WorktreeExistsError";
   }

--- a/src/run.ts
+++ b/src/run.ts
@@ -258,7 +258,7 @@ export async function run(options: RunOptions): Promise<number> {
         "tracker",
         ticket.id,
         caughtMessage(error),
-        "Check Tracker auth and network",
+        "Check the Tracker",
       );
     }
     // After the Worktree, so that a hard stop at any earlier stage leaves it on
@@ -267,6 +267,10 @@ export async function run(options: RunOptions): Promise<number> {
     try {
       await removeTicketWorktree(cwd, worktree);
       keptWorktree = undefined;
+    } catch (error) {
+      return stop("git", ticket.id, caughtMessage(error));
+    }
+    try {
       runBranchTip = await collectOntoRunBranch(cwd, {
         runBranch,
         branch,
@@ -275,10 +279,13 @@ export async function run(options: RunOptions): Promise<number> {
       });
       landed += 1;
     } catch (error) {
+      const gitError = caughtMessage(error);
       return stop(
         "git",
         ticket.id,
-        caughtMessage(error),
+        gitError === undefined
+          ? "ReadyRun could not merge the Ticket's Branch into the Run Branch"
+          : `ReadyRun could not merge the Ticket's Branch into the Run Branch. ${gitError}`,
       );
     }
   }

--- a/src/run.ts
+++ b/src/run.ts
@@ -66,15 +66,33 @@ function mergeMessage(ticket: Ticket): string {
 
 type HardStopStage = "tracker" | "git" | "spawn" | "worker";
 
+function caughtMessage(error: unknown): string | undefined {
+  return error instanceof Error ? error.message : undefined;
+}
+
 function hardStop(
   stdout: RunStdout,
   stage: HardStopStage,
-  ticketId?: string,
-  detail?: string,
+  ticketId: string | undefined,
+  detail: string | undefined,
+  landed: number,
+  runBranch: string,
+  worktree: string | undefined,
+  nextAction?: string,
 ): 1 {
   const ticketPrefix = ticketId === undefined ? "" : `Ticket ${ticketId} `;
   const suffix = detail === undefined ? "" : `: ${detail}`;
-  stdout.write(`Hard stop: ${ticketPrefix}failed at ${stage}${suffix}\n`);
+  const action = nextAction === undefined ? "" : `. ${nextAction}`;
+  stdout.write(`Hard stop: ${ticketPrefix}failed at ${stage}${suffix}${action}\n`);
+  if (landed === 0) {
+    stdout.write("0 Tickets landed; no Run Branch was created.\n");
+  } else {
+    const noun = landed === 1 ? "Ticket" : "Tickets";
+    stdout.write(`${landed} ${noun} landed on ${runBranch}.\n`);
+  }
+  if (worktree !== undefined) {
+    stdout.write(`Worktree kept at ${worktree}\n`);
+  }
   return 1;
 }
 
@@ -99,15 +117,32 @@ export async function run(options: RunOptions): Promise<number> {
     return 1;
   }
   const runBranch = runBranchName(new Date());
+  let landed = 0;
+  let keptWorktree: string | undefined;
+  const stop = (
+    stage: HardStopStage,
+    ticketId?: string,
+    detail?: string,
+    nextAction?: string,
+  ): 1 =>
+    hardStop(
+      stdout,
+      stage,
+      ticketId,
+      detail,
+      landed,
+      runBranch,
+      keptWorktree,
+      nextAction,
+    );
   let base;
   try {
     base = await resolveRunBase(cwd);
   } catch (error) {
-    return hardStop(
-      stdout,
+    return stop(
       "git",
       undefined,
-      error instanceof Error ? error.message : undefined,
+      caughtMessage(error),
     );
   }
   discloseBase(stdout, base);
@@ -125,8 +160,13 @@ export async function run(options: RunOptions): Promise<number> {
     let frontier;
     try {
       frontier = await config.tracker.frontier();
-    } catch {
-      return hardStop(stdout, "tracker");
+    } catch (error) {
+      return stop(
+        "tracker",
+        undefined,
+        caughtMessage(error),
+        "Check Tracker auth and network",
+      );
     }
     if (!unusedModelsWarned) {
       warnUnusedModelsByLabel(stdout, config.modelsByLabel, frontier);
@@ -141,12 +181,12 @@ export async function run(options: RunOptions): Promise<number> {
     let worktree;
     try {
       worktree = await createTicketWorktree(cwd, branch, runBranchTip);
+      keptWorktree = worktree;
     } catch (error) {
-      return hardStop(
-        stdout,
+      return stop(
         "git",
         ticket.id,
-        error instanceof Error ? error.message : undefined,
+        caughtMessage(error),
       );
     }
     started += 1;
@@ -161,15 +201,20 @@ export async function run(options: RunOptions): Promise<number> {
         effort: options.effort ?? config.effort,
         prompt: composeWorkerPrompt(config.tracker.promptCopy(ticket), context),
       });
-    } catch {
-      return hardStop(stdout, "spawn", ticket.id);
+    } catch (error) {
+      return stop(
+        "spawn",
+        ticket.id,
+        caughtMessage(error),
+        "Check the Worker binary and that it is logged in",
+      );
     }
     if (result.exitCode !== 0) {
-      return hardStop(
-        stdout,
+      return stop(
         "worker",
         ticket.id,
         `exit code ${result.exitCode}`,
+        "The Ticket remains on the Frontier",
       );
     }
     // Exit 0 is not success on its own: a Worker that did nothing also exits 0
@@ -180,27 +225,26 @@ export async function run(options: RunOptions): Promise<number> {
       clean = await worktreeIsClean(worktree);
       changed = await branchTreeDiffersFrom(cwd, branch, runBranchTip);
     } catch (error) {
-      return hardStop(
-        stdout,
+      return stop(
         "git",
         ticket.id,
-        error instanceof Error ? error.message : undefined,
+        caughtMessage(error),
       );
     }
     if (!clean) {
-      return hardStop(
-        stdout,
+      return stop(
         "worker",
         ticket.id,
         `left work uncommitted in ${worktree}`,
+        "The Ticket remains on the Frontier",
       );
     }
     if (!changed) {
-      return hardStop(
-        stdout,
+      return stop(
         "worker",
         ticket.id,
         `produced nothing on ${branch}`,
+        "The Ticket remains on the Frontier",
       );
     }
     try {
@@ -209,26 +253,32 @@ export async function run(options: RunOptions): Promise<number> {
       } else {
         await config.tracker.leaveFrontier(ticket);
       }
-    } catch {
-      return hardStop(stdout, "tracker", ticket.id);
+    } catch (error) {
+      return stop(
+        "tracker",
+        ticket.id,
+        caughtMessage(error),
+        "Check Tracker auth and network",
+      );
     }
     // After the Worktree, so that a hard stop at any earlier stage leaves it on
     // disk for the Consumer to look at (ADR 0029) — and because a Branch cannot
     // be deleted while a Worktree still has it checked out.
     try {
       await removeTicketWorktree(cwd, worktree);
+      keptWorktree = undefined;
       runBranchTip = await collectOntoRunBranch(cwd, {
         runBranch,
         branch,
         base: base.commit,
         message: mergeMessage(ticket),
       });
+      landed += 1;
     } catch (error) {
-      return hardStop(
-        stdout,
+      return stop(
         "git",
         ticket.id,
-        error instanceof Error ? error.message : undefined,
+        caughtMessage(error),
       );
     }
   }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -238,7 +238,10 @@ test("doctor refuses when there is no config file at the Consumer root", async (
       });
       assert.equal(exitCode, 1);
       assert.equal(checked, false);
-      assert.match(chunks.join(""), /readyrun\.config/);
+      const output = chunks.join("");
+      assert.match(output, /readyrun\.config/);
+      assert.match(output, /readyrun init/);
+      assert.doesNotMatch(output, /Doctor:/);
     },
   );
 });
@@ -296,6 +299,87 @@ test("multiple config files of the same basename are refused", async () => {
           return true;
         },
       );
+      const chunks: string[] = [];
+      const exitCode = await cli({
+        argv: ["doctor"],
+        cwd,
+        stdout: {
+          write(chunk: string) {
+            chunks.push(chunk);
+            return true;
+          },
+        },
+        doctor: async () => 0,
+      });
+      assert.equal(exitCode, 1);
+      const output = chunks.join("");
+      assert.match(output, /Multiple config files/);
+      assert.match(output, /Leave one file/);
+      assert.doesNotMatch(output, /Doctor:/);
+    },
+  );
+});
+
+test("a config that does not default-export defineConfig names a next action", async () => {
+  await withConsumerRoot(
+    async (cwd) => {
+      await writeFile(
+        join(cwd, "package.json"),
+        JSON.stringify({ type: "module" }),
+      );
+      await writeFile(
+        join(cwd, "readyrun.config.js"),
+        "export const model = \"composer-2\";\n",
+      );
+    },
+    async (cwd) => {
+      const chunks: string[] = [];
+      const exitCode = await cli({
+        argv: ["doctor"],
+        cwd,
+        stdout: {
+          write(chunk: string) {
+            chunks.push(chunk);
+            return true;
+          },
+        },
+        doctor: async () => 0,
+      });
+      assert.equal(exitCode, 1);
+      const output = chunks.join("");
+      assert.match(output, /must default-export defineConfig/);
+      assert.doesNotMatch(output, /Doctor:/);
+    },
+  );
+});
+
+test("a config that fails to load names a next action without a Doctor prefix", async () => {
+  await withConsumerRoot(
+    async (cwd) => {
+      await writeFile(
+        join(cwd, "package.json"),
+        JSON.stringify({ type: "module" }),
+      );
+      await writeFile(join(cwd, "readyrun.config.js"), "export default {\n");
+    },
+    async (cwd) => {
+      const chunks: string[] = [];
+      const exitCode = await cli({
+        argv: ["doctor"],
+        cwd,
+        stdout: {
+          write(chunk: string) {
+            chunks.push(chunk);
+            return true;
+          },
+        },
+        doctor: async () => 0,
+      });
+      assert.equal(exitCode, 1);
+      const output = chunks.join("");
+      assert.match(output, /Could not load the ReadyRun config/);
+      assert.match(output, /Fix the config file/);
+      assert.doesNotMatch(output, /Doctor:/);
     },
   );
 });

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -80,6 +80,7 @@ test("a label named in the selector that does not exist on the Tracker fails Doc
       chunks.join(""),
       /Doctor: label "does-not-exist" does not exist on the Tracker/,
     );
+    assert.match(chunks.join(""), /Check the Frontier selector/);
 
     const runExit = await run({
       config,

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -155,6 +155,13 @@ test("createTicketWorktree refuses a Branch that already exists, instead of a ra
       (error: unknown) => {
         assert.ok(error instanceof WorktreeExistsError);
         assert.match(error.message, /already has a Worktree for branch readyrun\/52/);
+        assert.match(
+          error.message,
+          /git worktree remove .*readyrun-52/,
+        );
+        assert.match(error.message, /git branch -D readyrun\/52/);
+        assert.match(error.message, /start a new Run/);
+        assert.doesNotMatch(error.message, /finish|continue|by hand/i);
         return true;
       },
     );

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -301,6 +301,7 @@ test("Doctor fails when ReadyRun cannot authenticate to GitHub", async () => {
       chunks.join(""),
       /Doctor: ReadyRun could not authenticate to GitHub/,
     );
+    assert.match(chunks.join(""), /Check the GitHub token/);
   } finally {
     await repo.cleanup();
   }
@@ -351,8 +352,53 @@ test("Doctor names a token that cannot see the repository, not a wrong repo stri
       output,
       /Doctor: this token cannot see GitHub repository acme\/widgets/,
     );
+    assert.match(output, /Check the token's access to that repository/);
     assert.doesNotMatch(output, /Could not resolve/);
     assert.doesNotMatch(output, /was not found/);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("Doctor does not print a raw GitHub GraphQL HTTP string as the failure", async () => {
+  const repo = await repoWithOrigin();
+  const adapter = github(
+    {
+      repo: "acme/widgets",
+      ready: "unblocked",
+      labels: ["ready-for-agent"],
+    },
+    {
+      token: "test-token",
+      fetch: async () =>
+        new Response(JSON.stringify({}), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        }),
+    },
+  );
+  const chunks: string[] = [];
+  try {
+    const exit = await doctor({
+      config: defineConfig({
+        tracker: adapter,
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(exit, 1);
+    const output = chunks.join("");
+    assert.match(output, /Doctor: ReadyRun could not reach GitHub/);
+    assert.match(output, /Check Tracker auth and network/);
+    assert.match(output, /GitHub GraphQL HTTP 500/);
+    assert.doesNotMatch(output, /^Doctor: GitHub GraphQL HTTP 500$/m);
   } finally {
     await repo.cleanup();
   }

--- a/test/linear.test.ts
+++ b/test/linear.test.ts
@@ -355,6 +355,50 @@ test("Doctor fails when ReadyRun cannot authenticate to Linear", async () => {
       chunks.join(""),
       /Doctor: ReadyRun could not authenticate to Linear/,
     );
+    assert.match(chunks.join(""), /Check the Linear token/);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("Doctor does not print a raw Linear GraphQL HTTP string as the failure", async () => {
+  const repo = await throwawayRepo();
+  const adapter = linear(
+    {
+      ready: "unblocked",
+      label: "ready-for-agent",
+    },
+    {
+      token: "test-token",
+      fetch: async () =>
+        new Response(JSON.stringify({}), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        }),
+    },
+  );
+  const chunks: string[] = [];
+  try {
+    const exit = await doctor({
+      config: defineConfig({
+        tracker: adapter,
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(exit, 1);
+    const output = chunks.join("");
+    assert.match(output, /Doctor: ReadyRun could not reach Linear/);
+    assert.match(output, /Check Tracker auth and network/);
+    assert.match(output, /Linear GraphQL HTTP 500/);
+    assert.doesNotMatch(output, /^Doctor: Linear GraphQL HTTP 500$/m);
   } finally {
     await repo.cleanup();
   }

--- a/test/linear.test.ts
+++ b/test/linear.test.ts
@@ -404,6 +404,47 @@ test("Doctor does not print a raw Linear GraphQL HTTP string as the failure", as
   }
 });
 
+test("Doctor does not print a raw Linear fetch throw as the failure", async () => {
+  const repo = await throwawayRepo();
+  const adapter = linear(
+    {
+      ready: "unblocked",
+      label: "ready-for-agent",
+    },
+    {
+      token: "test-token",
+      fetch: async () => {
+        throw new Error("fetch failed");
+      },
+    },
+  );
+  const chunks: string[] = [];
+  try {
+    const exit = await doctor({
+      config: defineConfig({
+        tracker: adapter,
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+    assert.equal(exit, 1);
+    const output = chunks.join("");
+    assert.match(output, /Doctor: ReadyRun could not reach Linear/);
+    assert.match(output, /Check Tracker auth and network/);
+    assert.match(output, /fetch failed/);
+    assert.doesNotMatch(output, /^Doctor: fetch failed$/m);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
 test("the Worker prompt names this Ticket as Linear and the Ticket id", async () => {
   const { adapter } = linearFromWorld(world);
   const [picked] = await adapter.frontier();

--- a/test/run-hard-stop.test.ts
+++ b/test/run-hard-stop.test.ts
@@ -302,7 +302,7 @@ test("a Tracker failure finishing a Ticket hard-stops the Run and names that Tic
       chunks.join(""),
       /Hard stop: Ticket 52 failed at tracker: GitHub API 500/,
     );
-    assert.match(chunks.join(""), /Check Tracker auth and network/);
+    assert.match(chunks.join(""), /Check the Tracker/);
   } finally {
     await repo.cleanup();
   }

--- a/test/run-hard-stop.test.ts
+++ b/test/run-hard-stop.test.ts
@@ -8,7 +8,7 @@ import { createTrackerAdapter, defineConfig, run } from "../src/mod.ts";
 import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
 import { createWorkerAdapter } from "../src/worker-adapter.ts";
 import { ticket } from "./tracker-adapter-contract.ts";
-import { commitMismatchedNpmLockfile, throwawayRepo } from "./throwaway-repo.ts";
+import { commitMismatchedNpmLockfile, commitWorkerWork, runBranch, throwawayRepo } from "./throwaway-repo.ts";
 
 const exec = promisify(execFile);
 const silent = { write(_chunk?: string) { return true; } };
@@ -95,6 +95,11 @@ test("a Worker exiting non-zero hard-stops the Run without skip or retry", async
     );
     const output = chunks.join("");
     assert.match(output, /Hard stop: Ticket 52 failed at worker: exit code 42/);
+    assert.match(output, /The Ticket remains on the Frontier/);
+    assert.doesNotMatch(output, /claude auth login/);
+    assert.match(output, /0 Tickets landed; no Run Branch was created/);
+    assert.doesNotMatch(output, /landed on readyrun\/run-/);
+    assert.match(output, /Worktree kept at .*readyrun-52/);
   } finally {
     await repo.cleanup();
   }
@@ -133,7 +138,12 @@ test("a Tracker API or auth failure hard-stops the Run", async () => {
 
     assert.equal(exitCode, 1);
     assert.equal(worker.spawns.length, 0);
-    assert.match(chunks.join(""), /Hard stop: failed at tracker/);
+    assert.match(
+      chunks.join(""),
+      /Hard stop: failed at tracker: 401 Unauthorized/,
+    );
+    assert.match(chunks.join(""), /Check Tracker auth and network/);
+    assert.doesNotMatch(chunks.join(""), /Worktree kept/);
   } finally {
     await repo.cleanup();
   }
@@ -244,7 +254,11 @@ test("a missing or unauthenticated Worker at spawn hard-stops the Run", async ()
 
     assert.equal(exitCode, 1);
     assert.deepEqual(attempted, ["52"]);
-    assert.match(chunks.join(""), /Hard stop: Ticket 52 failed at spawn/);
+    assert.match(
+      chunks.join(""),
+      /Hard stop: Ticket 52 failed at spawn: Worker is not logged in/,
+    );
+    assert.match(chunks.join(""), /Check the Worker binary and that it is logged in/);
   } finally {
     await repo.cleanup();
   }
@@ -284,7 +298,57 @@ test("a Tracker failure finishing a Ticket hard-stops the Run and names that Tic
 
     assert.equal(exitCode, 1);
     assert.deepEqual(worker.spawns.map((spawn) => spawn.ticket.id), ["52"]);
-    assert.match(chunks.join(""), /Hard stop: Ticket 52 failed at tracker/);
+    assert.match(
+      chunks.join(""),
+      /Hard stop: Ticket 52 failed at tracker: GitHub API 500/,
+    );
+    assert.match(chunks.join(""), /Check Tracker auth and network/);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a hard stop after a merge names the Run Branch and how many Tickets landed", async () => {
+  const repo = await throwawayRepo();
+  const worker = createWorkerAdapter({
+    async spawn(request) {
+      if (request.ticket.id === "57") {
+        return { exitCode: 42 };
+      }
+      await commitWorkerWork(request);
+      return { exitCode: 0 };
+    },
+  });
+  const chunks: string[] = [];
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [
+            ticket({ id: "52", title: "Fix the thing" }),
+            ticket({ id: "57", title: "Fix the other thing" }),
+          ],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker,
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    const output = chunks.join("");
+    const branch = await runBranch(repo.cwd);
+    assert.match(output, new RegExp(`1 Ticket landed on ${branch}`));
+    assert.doesNotMatch(output, /no Run Branch was created/);
   } finally {
     await repo.cleanup();
   }

--- a/test/run-worker-commit.test.ts
+++ b/test/run-worker-commit.test.ts
@@ -52,6 +52,7 @@ test("a Worker exiting 0 with a dirty Worktree hard-stops the Run and leaves its
       chunks.join(""),
       /Hard stop: Ticket 52 failed at worker: left work uncommitted in .*readyrun-52/,
     );
+    assert.match(chunks.join(""), /The Ticket remains on the Frontier/);
     const worktree = worker.spawns[0]?.cwd;
     assert.ok(worktree);
     await access(join(worktree, "ticket-52.txt"));
@@ -88,6 +89,7 @@ test("a Worker exiting 0 whose Branch tree matches the base hard-stops the Run a
       chunks.join(""),
       /Hard stop: Ticket 52 failed at worker: produced nothing on readyrun\/52/,
     );
+    assert.match(chunks.join(""), /The Ticket remains on the Frontier/);
   } finally {
     await repo.cleanup();
   }
@@ -121,6 +123,7 @@ test("a Worker exiting 0 after an empty commit hard-stops the Run and leaves its
       chunks.join(""),
       /Hard stop: Ticket 52 failed at worker: produced nothing on readyrun\/52/,
     );
+    assert.match(chunks.join(""), /The Ticket remains on the Frontier/);
     assert.equal(
       await onDisk(join(repo.cwd, ".readyrun", "worktrees", "readyrun-52")),
       true,
@@ -192,6 +195,7 @@ test("a Worker that commits on another Branch leaves its Branch's tree matching 
       chunks.join(""),
       /Hard stop: Ticket 52 failed at worker: produced nothing on readyrun\/52/,
     );
+    assert.match(chunks.join(""), /The Ticket remains on the Frontier/);
   } finally {
     await repo.cleanup();
   }

--- a/test/run-worktree-lifetime.test.ts
+++ b/test/run-worktree-lifetime.test.ts
@@ -160,6 +160,8 @@ test("re-running a Ticket whose Worktree was kept still hard-stops with Worktree
       chunks.join(""),
       /Hard stop: Ticket 52 failed at git: ReadyRun already has a Worktree for branch readyrun\/52/,
     );
+    assert.match(chunks.join(""), /git worktree remove .*readyrun-52/);
+    assert.match(chunks.join(""), /git branch -D readyrun\/52/);
     assert.equal(await onDisk(worktreeOf(repo.cwd, "52")), true);
   } finally {
     await repo.cleanup();


### PR DESCRIPTION
## Why

A Consumer hitting Doctor or a hard stop today gets a vendor GraphQL string, a stage name, or nothing. SpeechDeck's first afternoon of `doctor` / `run` produced GitHub "Could not resolve to a Repository" (reads as a typo in `github({ repo })`), `Hard stop: Ticket 52 failed at worker: exit code 1` with no next action, and a leftover Worktree with no recovery commands. Tracker and spawn `catch` blocks swallowed the thrown error entirely. After a Run Branch exists, a hard stop can already hold merged Tickets — an operator who reads only "Run failed" would reasonably throw that work away.

Fixes #62.

## What

Doctor, config load, and Run hard stops each name the cause in ReadyRun language and a next action. A hard stop also recaps what actually exists: landed Tickets (including 0), the Run Branch only if that ref exists, and a kept Worktree only if this Run created one.

## Workarounds

Git plumbing failures other than leftover Worktree and merge, and Doctor probe failures, still use the existing cause (install output, probe detail, raw git) without a second ReadyRun next action. Inventing "check the git error" or `claude auth login` would be the vendor-only shape this ticket was written to kill.

## Test plan

- [ ] Doctor: GitHub "Could not resolve to a Repository" stays cannot-see, not a repo typo; unknown GitHub/Linear GraphQL/HTTP is ReadyRun + next action
- [ ] Run: tracker/spawn/leave-Frontier hard stops include the caught error; leftover Worktree names `git worktree remove` / `git branch -D`
- [ ] Hard stop with 0 merges says no Run Branch was created; after a merge it names that Run Branch and the landed count
- [ ] Missing config names `readyrun init` and is not branded `Doctor:`


Made with [Cursor](https://cursor.com)