### PR TITLE
Unify triage labels on the canonical role vocabulary

### DIFF
--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,15 +1,36 @@
 # Triage Labels
 
-`/matt-triage` speaks in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+`/matt-triage` speaks in terms of triage roles. This repo uses those role names verbatim as its label strings, so the mapping below is an identity mapping — there is no translation step.
+
+## Category roles
+
+Every triaged issue carries exactly one.
 
 | Canonical role | Label in this repo's tracker | Meaning |
-| --------------- | ----------------------------- | ---------------------------------------- |
+| -------------- | ---------------------------- | ------------------------------ |
+| `bug` | `bug` | Something is broken |
+| `enhancement` | `enhancement` | New feature or improvement |
+
+## State roles
+
+Every triaged issue carries exactly one.
+
+| Canonical role | Label in this repo's tracker | Meaning |
+| ----------------- | ---------------------------- | ---------------------------------------- |
 | `needs-triage` | `needs-triage` | Maintainer needs to evaluate this issue |
 | `needs-info` | `needs-info` | Waiting on reporter for more information |
 | `ready-for-agent` | `ready-for-agent` | Fully specified, ready for an AFK agent |
 | `ready-for-human` | `ready-for-human` | Requires human implementation |
 | `wontfix` | `wontfix` | Will not be actioned |
 
-When `/matt-triage` mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+## Labels outside the triage vocabulary
 
-Edit the right-hand column to match whatever vocabulary this repo's tracker actually uses.
+`spec` is not a state. It marks a published spec that acts as the parent for implementation tickets and is not itself work, so it sits alongside a state role rather than replacing one.
+
+`documentation` narrows a category rather than replacing it; an issue carrying it still needs `bug` or `enhancement`.
+
+Everything else GitHub creates by default (`duplicate`, `invalid`, `question`, `help wanted`, `good first issue`, `accessibility`) is unused by triage.
+
+## History
+
+`needs-refinement` was this repo's own state for "parked after the v0 grill, needs another session before it is spec." It was retired on 2026-09-04 in favour of `needs-triage`, whose canonical meaning already covers it, and the thirteen issues carrying it were migrated. Do not reintroduce a second name for "evaluation is not finished."

--- a/docs/specs/readyrun-v0.md
+++ b/docs/specs/readyrun-v0.md
@@ -213,7 +213,7 @@ There is no prior art in this repo — it currently contains only the glossary a
 
 ## Out of Scope
 
-The following are parked deliberately and tracked as `needs-refinement` issues. None is part of v0, and none should be pulled into the implementation queue without another grilling session:
+The following are parked deliberately and tracked as `needs-triage` issues. None is part of v0, and none should be pulled into the implementation queue without another grilling session:
 
 - How a Ticket lands — pushing for review versus staying local, and how work is eventually integrated ([#1](https://github.com/MichaelBuss/readyrun/issues/1)).
 - A second Worker that reviews the first ([#2](https://github.com/MichaelBuss/readyrun/issues/2)). A review-shaped Ticket on the Frontier is just a Ticket; by-label model routing is not automatic review.


### PR DESCRIPTION
## Why

`docs/agents/triage-labels.md` claimed to map the five canonical triage roles onto this repo's labels, but three of the labels on the right-hand side (`needs-triage`, `needs-info`, `ready-for-human`) did not exist in the tracker, while the state label actually in use — `needs-refinement` — was not in the table at all. Any agent following the doc would have tried to apply labels that were not there.

Found while triaging #70, where the mismatch surfaced: the issue carried a state that the documented vocabulary had no name for.

## What

Rewrites the mapping as an identity mapping over the canonical roles, splits category from state roles, and documents `spec` and `documentation` as sitting outside the state machine rather than competing with it.

## How

The tracker side of this is already done and is not in the diff: the three missing labels now exist, the thirteen issues carrying `needs-refinement` were migrated to `needs-triage`, and `needs-refinement` was deleted. The History section records that retirement so a second name for "evaluation is not finished" does not come back. The v0 spec's Out of Scope paragraph referenced the retired label and now names `needs-triage`.
