### PR TITLE
Report how a clean stop landed (#98)

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -5,6 +5,7 @@ import {
   normalizeRepository,
   originRepository,
   resolveRunBase,
+  shortCommit,
   unignoredInstallOutput,
   type RunBase,
 } from "./git.ts";
@@ -114,7 +115,7 @@ function workerBinaryExists(bin: string): boolean {
 }
 
 function baseLine(base: RunBase): string {
-  const commit = base.commit.slice(0, 7);
+  const commit = shortCommit(base.commit);
   // A detached checkout is on no branch, so it is named the default branch
   // rather than told it differs from one: the base may well be that branch's
   // own tip.

--- a/src/git.ts
+++ b/src/git.ts
@@ -178,6 +178,13 @@ export type RunBase = {
   dirty: boolean;
 };
 
+// How a commit is named to a Consumer, wherever one is named: the base a Run
+// discloses at start and the base its report says the Run Branch was cut from
+// have to be the same string to be recognisable as the same commit.
+export function shortCommit(commit: string): string {
+  return commit.slice(0, 7);
+}
+
 // One read of the checkout a Run starts from: the commit every Worktree is cut
 // from, plus what a Consumer cannot see from that commit alone — that the base
 // is not the default branch, and that uncommitted work here reaches no

--- a/src/run.ts
+++ b/src/run.ts
@@ -117,11 +117,11 @@ function hardStop(
   return 1;
 }
 
-// Symmetric with the hard-stop report, because a clean stop leaves a Consumer
-// with the same question: how many Tickets landed, whether the Run Branch ref
-// exists, and where it started. It prescribes no push and no merge — ReadyRun
-// cannot decline to own integration and then recommend a workflow for it
-// (ADR 0033).
+// A clean stop leaves a Consumer with the question the hard-stop report already
+// answers — how many Tickets landed, and whether the Run Branch ref exists —
+// plus the two a hard stop has no room for: the base and why the Run stopped.
+// It prescribes no push and no merge, because ReadyRun cannot decline to own
+// integration and then recommend a workflow for it (ADR 0033).
 function completionReport(
   stdout: RunStdout,
   reason: CleanStop,
@@ -210,9 +210,9 @@ async function runWithLiveness(
   }
   discloseBase(stdout, base);
   stdout.write(`Run Branch: ${runBranch}\n`);
-  const complete = (reason: CleanStop, cutFrom: string): 0 => {
+  const complete = (reason: CleanStop): 0 => {
     live.stop();
-    return completionReport(stdout, reason, cap, landed, runBranch, cutFrom);
+    return completionReport(stdout, reason, cap, landed, runBranch, base.commit);
   };
   // A Ticket's Branch is cut from the Run Branch's tip, which until the first
   // Ticket lands is the base the Run resolved at start (ADR 0028).
@@ -243,7 +243,7 @@ async function runWithLiveness(
     }
     const ticket = frontier[0];
     if (ticket === undefined) {
-      return complete("frontier-empty", base.commit);
+      return complete("frontier-empty");
     }
 
     const branch = config.tracker.branchName(ticket);
@@ -366,5 +366,5 @@ async function runWithLiveness(
       );
     }
   }
-  return complete("cap", base.commit);
+  return complete("cap");
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,6 +9,7 @@ import {
   createTicketWorktree,
   removeTicketWorktree,
   resolveRunBase,
+  shortCommit,
   worktreeIsClean,
 } from "./git.ts";
 import { composeWorkerPrompt } from "./prompt.ts";
@@ -67,6 +68,30 @@ function mergeMessage(ticket: Ticket): string {
 
 type HardStopStage = "tracker" | "git" | "spawn" | "worker";
 
+// The two clean stops (ADR 0013). Which one it was is the only fact in the
+// report a Consumer cannot recover from git afterwards, and it is what says
+// whether work remains on the Frontier.
+type CleanStop = "frontier-empty" | "cap";
+
+function ticketNoun(count: number): string {
+  return count === 1 ? "Ticket" : "Tickets";
+}
+
+// A Run Branch is created lazily at the first merge (ADR 0028), so a Run that
+// landed nothing must not name the ref it disclosed at start: git has none.
+// The base is named only where there is a Branch that was cut from it.
+function landingLine(
+  landed: number,
+  runBranch: string,
+  base?: string,
+): string {
+  if (landed === 0) {
+    return "0 Tickets landed; no Run Branch was created.";
+  }
+  const cutFrom = base === undefined ? "" : `, cut from ${shortCommit(base)}`;
+  return `${landed} ${ticketNoun(landed)} landed on ${runBranch}${cutFrom}.`;
+}
+
 function caughtMessage(error: unknown): string | undefined {
   return error instanceof Error ? error.message : undefined;
 }
@@ -85,16 +110,35 @@ function hardStop(
   const suffix = detail === undefined ? "" : `: ${detail}`;
   const action = nextAction === undefined ? "" : `. ${nextAction}`;
   stdout.write(`Hard stop: ${ticketPrefix}failed at ${stage}${suffix}${action}\n`);
-  if (landed === 0) {
-    stdout.write("0 Tickets landed; no Run Branch was created.\n");
-  } else {
-    const noun = landed === 1 ? "Ticket" : "Tickets";
-    stdout.write(`${landed} ${noun} landed on ${runBranch}.\n`);
-  }
+  stdout.write(`${landingLine(landed, runBranch)}\n`);
   if (worktree !== undefined) {
     stdout.write(`Worktree kept at ${worktree}\n`);
   }
   return 1;
+}
+
+// Symmetric with the hard-stop report, because a clean stop leaves a Consumer
+// with the same question: how many Tickets landed, whether the Run Branch ref
+// exists, and where it started. It prescribes no push and no merge — ReadyRun
+// cannot decline to own integration and then recommend a workflow for it
+// (ADR 0033).
+function completionReport(
+  stdout: RunStdout,
+  reason: CleanStop,
+  cap: number,
+  landed: number,
+  runBranch: string,
+  base: string,
+): 0 {
+  stdout.write(
+    reason === "frontier-empty"
+      ? "Run complete: the Frontier is empty\n"
+      : `Run complete: cap of ${cap} ${
+        ticketNoun(cap)
+      } reached; the Frontier may still hold work\n`,
+  );
+  stdout.write(`${landingLine(landed, runBranch, base)}\n`);
+  return 0;
 }
 
 export async function run(options: RunOptions): Promise<number> {
@@ -166,6 +210,10 @@ async function runWithLiveness(
   }
   discloseBase(stdout, base);
   stdout.write(`Run Branch: ${runBranch}\n`);
+  const complete = (reason: CleanStop, cutFrom: string): 0 => {
+    live.stop();
+    return completionReport(stdout, reason, cap, landed, runBranch, cutFrom);
+  };
   // A Ticket's Branch is cut from the Run Branch's tip, which until the first
   // Ticket lands is the base the Run resolved at start (ADR 0028).
   let runBranchTip = base.commit;
@@ -195,7 +243,7 @@ async function runWithLiveness(
     }
     const ticket = frontier[0];
     if (ticket === undefined) {
-      return 0;
+      return complete("frontier-empty", base.commit);
     }
 
     const branch = config.tracker.branchName(ticket);
@@ -318,5 +366,5 @@ async function runWithLiveness(
       );
     }
   }
-  return 0;
+  return complete("cap", base.commit);
 }

--- a/test/base-disclosure.test.ts
+++ b/test/base-disclosure.test.ts
@@ -61,6 +61,10 @@ test("a Run names the base commit and the Run Branch before it claims a Ticket, 
       "Worktree",
       "Ticket 52  Ticket 52  1/1  readyrun/52",
       "Worker",
+      "Run complete: cap of 1 Ticket reached; the Frontier may still hold work",
+      `1 Ticket landed on ${await runBranch(repo.cwd)}, cut from ${
+        base.slice(0, 7)
+      }.`,
     ]);
   } finally {
     await repo.cleanup();
@@ -180,6 +184,10 @@ test("Doctor and a Run disclose a dirty, non-default base in the same words", as
       "Worktree",
       "Ticket 52  Ticket 52  1/1  readyrun/52",
       "Worker",
+      "Run complete: cap of 1 Ticket reached; the Frontier may still hold work",
+      `1 Ticket landed on ${await runBranch(repo.cwd)}, cut from ${
+        base.slice(0, 7)
+      }.`,
     ]);
   } finally {
     await repo.cleanup();

--- a/test/run-completion-report.test.ts
+++ b/test/run-completion-report.test.ts
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { defineConfig, run } from "../src/mod.ts";
+import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
+import { ticket } from "./tracker-adapter-contract.ts";
+import { git, runBranch, runBranches, throwawayRepo } from "./throwaway-repo.ts";
+
+function capturing(): { chunks: string[]; stdout: { write(chunk: string): true } } {
+  const chunks: string[] = [];
+  return {
+    chunks,
+    stdout: {
+      write(chunk: string) {
+        chunks.push(chunk);
+        return true;
+      },
+    },
+  };
+}
+
+function lines(chunks: string[]): string[] {
+  return chunks.join("").split("\n").filter(Boolean);
+}
+
+function lastTwo(chunks: string[]): string[] {
+  return lines(chunks).slice(-2);
+}
+
+test("a Run that empties the Frontier reports the Tickets it landed, the Run Branch it collected them onto, the base it was cut from, and the empty Frontier", async () => {
+  const repo = await throwawayRepo();
+  const out = capturing();
+  try {
+    const base = await git(repo.cwd, ["rev-parse", "HEAD"]);
+
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [
+            ticket({ id: "52", title: "Fix the thing" }),
+            ticket({ id: "57", title: "Fix the other thing" }),
+          ],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cap: 5,
+      cwd: repo.cwd,
+      stdout: out.stdout,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(lastTwo(out.chunks), [
+      "Run complete: the Frontier is empty",
+      `2 Tickets landed on ${await runBranch(repo.cwd)}, cut from ${
+        base.slice(0, 7)
+      }.`,
+    ]);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a Run that stops on the cap names the cap as the reason, so it is clear that work may remain", async () => {
+  const repo = await throwawayRepo();
+  const out = capturing();
+  try {
+    const base = await git(repo.cwd, ["rev-parse", "HEAD"]);
+
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [
+            ticket({ id: "52", title: "Fix the thing" }),
+            ticket({ id: "57", title: "Fix the other thing" }),
+          ],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: out.stdout,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(lastTwo(out.chunks), [
+      "Run complete: cap of 1 Ticket reached; the Frontier may still hold work",
+      `1 Ticket landed on ${await runBranch(repo.cwd)}, cut from ${
+        base.slice(0, 7)
+      }.`,
+    ]);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a Run that lands nothing says no Run Branch was created, and names no ref that does not exist", async () => {
+  const repo = await throwawayRepo();
+  const out = capturing();
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "99", labels: ["other"] })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cap: 3,
+      cwd: repo.cwd,
+      stdout: out.stdout,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(await runBranches(repo.cwd), []);
+    assert.deepEqual(lastTwo(out.chunks), [
+      "Run complete: the Frontier is empty",
+      "0 Tickets landed; no Run Branch was created.",
+    ]);
+    // The disclosure at the top names the Run Branch it may create; the report
+    // must not repeat a name git has no ref for.
+    assert.equal(
+      lines(out.chunks).filter((line) => line.includes("readyrun/run-")).length,
+      1,
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a completion report prescribes no integration: no push, no merge, no pull request", async () => {
+  const repo = await throwawayRepo();
+  const capped = capturing();
+  const emptied = capturing();
+  try {
+    const config = () =>
+      defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "52" }), ticket({ id: "57" })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      });
+
+    assert.equal(
+      await run({ config: config(), cap: 1, cwd: repo.cwd, stdout: capped.stdout }),
+      0,
+    );
+    assert.equal(
+      await run({ config: config(), cap: 5, cwd: repo.cwd, stdout: emptied.stdout }),
+      0,
+    );
+
+    for (const out of [capped, emptied]) {
+      assert.doesNotMatch(
+        lastTwo(out.chunks).join("\n"),
+        /push|merg|pull request|\bPR\b/i,
+      );
+    }
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("off a TTY the completion report is plain lines, with no spinner control characters", async () => {
+  const repo = await throwawayRepo();
+  const out = capturing();
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "52" })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: out.stdout,
+    });
+
+    assert.equal(exitCode, 0);
+    const text = out.chunks.join("");
+    assert.doesNotMatch(text, /[\r\x1b]/);
+    assert.match(text, /^Run complete: cap of 1 Ticket reached[^\n]*\n/m);
+    assert.match(text, /^1 Ticket landed on readyrun\/run-[^\n]*\n/m);
+  } finally {
+    await repo.cleanup();
+  }
+});

--- a/test/run-completion-report.test.ts
+++ b/test/run-completion-report.test.ts
@@ -22,7 +22,9 @@ function lines(chunks: string[]): string[] {
   return chunks.join("").split("\n").filter(Boolean);
 }
 
-function lastTwo(chunks: string[]): string[] {
+// The report is the last two lines a Run writes: the stop reason, then the
+// landing.
+function reportLines(chunks: string[]): string[] {
   return lines(chunks).slice(-2);
 }
 
@@ -51,7 +53,7 @@ test("a Run that empties the Frontier reports the Tickets it landed, the Run Bra
     });
 
     assert.equal(exitCode, 0);
-    assert.deepEqual(lastTwo(out.chunks), [
+    assert.deepEqual(reportLines(out.chunks), [
       "Run complete: the Frontier is empty",
       `2 Tickets landed on ${await runBranch(repo.cwd)}, cut from ${
         base.slice(0, 7)
@@ -87,7 +89,7 @@ test("a Run that stops on the cap names the cap as the reason, so it is clear th
     });
 
     assert.equal(exitCode, 0);
-    assert.deepEqual(lastTwo(out.chunks), [
+    assert.deepEqual(reportLines(out.chunks), [
       "Run complete: cap of 1 Ticket reached; the Frontier may still hold work",
       `1 Ticket landed on ${await runBranch(repo.cwd)}, cut from ${
         base.slice(0, 7)
@@ -119,7 +121,7 @@ test("a Run that lands nothing says no Run Branch was created, and names no ref 
 
     assert.equal(exitCode, 0);
     assert.deepEqual(await runBranches(repo.cwd), []);
-    assert.deepEqual(lastTwo(out.chunks), [
+    assert.deepEqual(reportLines(out.chunks), [
       "Run complete: the Frontier is empty",
       "0 Tickets landed; no Run Branch was created.",
     ]);
@@ -159,9 +161,11 @@ test("a completion report prescribes no integration: no push, no merge, no pull 
       0,
     );
 
+    // The whole Run, not just the report: a clean stop must not suggest
+    // integration anywhere it speaks.
     for (const out of [capped, emptied]) {
       assert.doesNotMatch(
-        lastTwo(out.chunks).join("\n"),
+        out.chunks.join(""),
         /push|merg|pull request|\bPR\b/i,
       );
     }

--- a/test/run-hard-stop.test.ts
+++ b/test/run-hard-stop.test.ts
@@ -347,7 +347,9 @@ test("a hard stop after a merge names the Run Branch and how many Tickets landed
     assert.equal(exitCode, 1);
     const output = chunks.join("");
     const branch = await runBranch(repo.cwd);
-    assert.match(output, new RegExp(`1 Ticket landed on ${branch}`));
+    // The whole line: a hard stop names the Run Branch and stops there, where a
+    // clean stop goes on to name the base it was cut from.
+    assert.match(output, new RegExp(`^1 Ticket landed on ${branch}\\.$`, "m"));
     assert.doesNotMatch(output, /no Run Branch was created/);
   } finally {
     await repo.cleanup();


### PR DESCRIPTION
## Why

A clean stop — empty Frontier or the cap — returned without writing anything, so the `Run Branch:` line printed before the loop started was the last word on it. That ref is created lazily at the first merge (ADR 0028), so the disclosure could turn out false with nothing ever confirming or retracting it. A Run that landed three Tickets and one that landed none were indistinguishable on stdout without going to git. The hard-stop path already reported this; the clean stops never did.

## What

Both clean stops now end with a completion report (ADR 0033): the stop reason (empty Frontier vs. cap, the one fact git can't recover afterwards), how many Tickets landed, the Run Branch, and the base it was cut from. A Run that landed nothing says so instead of naming a ref that doesn't exist, reusing the line the hard-stop report already wrote for that case. Nothing in the output suggests a push, a merge, or a pull request.

## How

Both reports now share one `landingLine` helper; the hard-stop report is otherwise unchanged. The base is named via a new `shortCommit" in `git.ts`, shared with `doctor.ts`, so the completion report and the start-of-run disclosure name the same commit identically.


Made with [Cursor](https://cursor.com)