### PR TITLE
Tell a finished Ticket where its work went (#99)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -42,6 +42,10 @@ _Avoid_: main
 The one **Branch** a **Run** collects its finished **Tickets** onto, so a **Run** leaves one thing to review instead of one per **Ticket**.
 _Avoid_: integration branch, trunk, main
 
+**Landing**:
+Where a finished **Ticket**'s work went: the **Run Branch** it was collected onto and the merge commit that collected it. What a **Ticket** is told as it leaves the **Frontier**, because its own **Branch** is gone by then.
+_Avoid_: handoff, location (unqualified), PR, remote
+
 **Worktree**:
 The directory a **Worker** runs in; one per **Ticket**, on that **Ticket**’s **Branch**. Disposable: the **Branch** carries the work forward, not the directory.
 _Avoid_: clone, cwd mode, workspace (somewhere the **Consumer** continues by hand)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ import { createTrackerAdapter, defineConfig } from "@readyrun/readyrun";
 
 const jira = createTrackerAdapter({
   frontier() { /* return this Tracker's ready Tickets */ },
-  leaveFrontier(ticket) { /* move the Ticket off the Frontier */ },
+  leaveFrontier(ticket, landing) {
+    /* move the Ticket off the Frontier, and say where its work went:
+       landing.runBranch and landing.mergeCommit, local to this machine */
+  },
 });
 
 defineConfig({ tracker: jira, worker: cursor(), model: "composer-2" });

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -2,8 +2,10 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import {
   createTrackerAdapter,
+  type Landing,
   type TrackerAdapter,
 } from "../tracker-adapter.ts";
+import { shortCommit } from "../git.ts";
 import type { Ticket } from "../ticket.ts";
 import { assertKnownKeys } from "../unknown-keys.ts";
 
@@ -268,7 +270,7 @@ export function github(
       branchName(ticket) {
         return `readyrun/${ticket.id}`;
       },
-      async leaveFrontier(ticket) {
+      async leaveFrontier(ticket, landing) {
         for (const label of options.labels) {
           await rest(
             "DELETE",
@@ -278,10 +280,7 @@ export function github(
         await rest(
           "POST",
           `/repos/${owner}/${name}/issues/${ticket.id}/comments`,
-          {
-            body:
-              "ReadyRun: this Ticket left the Frontier after a successful Worker.",
-          },
+          { body: landingComment(landing) },
         );
       },
       promptCopy(ticket) {
@@ -291,6 +290,20 @@ export function github(
     }),
     { options },
   );
+}
+
+// The Ticket's own Branch is gone by the time this is written (ADR 0028), so
+// the Run Branch and the merge commit are the only pointers a reviewer has —
+// and the ref is disclosed as local, because ReadyRun never pushes and a Ticket
+// naming an unfetchable ref as though it were shared is a lie (ADR 0033).
+function landingComment(landing: Landing): string {
+  return [
+    "ReadyRun: this Ticket left the Frontier after a successful Worker.",
+    "",
+    `The work landed on the Run Branch \`${landing.runBranch}\` as merge commit \`${
+      shortCommit(landing.mergeCommit)
+    }\`. That ref is local to the machine that ran the Run — ReadyRun never pushes, so it cannot be fetched from anywhere else.`,
+  ].join("\n");
 }
 
 function matchesFrontier(

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import type { Ticket } from "./ticket.ts";
-import type { TrackerAdapter } from "./tracker-adapter.ts";
+import type { Landing, TrackerAdapter } from "./tracker-adapter.ts";
 import type { Effort, Permissions, WorkerAdapter } from "./worker-adapter.ts";
 import { assertKnownKeys } from "./unknown-keys.ts";
 
@@ -24,7 +24,7 @@ export type ReadyRunConfig = {
   effort?: Effort;
   contextFile?: string;
   cap?: number;
-  leaveFrontier?: (ticket: Ticket) => void | Promise<void>;
+  leaveFrontier?: (ticket: Ticket, landing: Landing) => void | Promise<void>;
 };
 
 export function defineConfig<T extends ReadyRunConfig>(config: T): T & {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -9,7 +9,7 @@ export type { RunOptions } from "./run.ts";
 export { DefaultBranchError, WorktreeExistsError, WorktreeInstallError } from "./git.ts";
 export type { Ticket } from "./ticket.ts";
 export { createTrackerAdapter } from "./tracker-adapter.ts";
-export type { TrackerAdapter, TrackerInspect } from "./tracker-adapter.ts";
+export type { Landing, TrackerAdapter, TrackerInspect } from "./tracker-adapter.ts";
 export type { Effort, Permissions, SpawnRequest, WorkerAdapter } from "./worker-adapter.ts";
 export { UnknownConfigKeyError } from "./unknown-keys.ts";
 export { github } from "./adapters/github.ts";

--- a/src/run.ts
+++ b/src/run.ts
@@ -324,23 +324,10 @@ async function runWithLiveness(
         "The Ticket remains on the Frontier",
       );
     }
-    try {
-      if (config.leaveFrontier) {
-        await config.leaveFrontier(ticket);
-      } else {
-        await config.tracker.leaveFrontier(ticket);
-      }
-    } catch (error) {
-      return stop(
-        "tracker",
-        ticket.id,
-        caughtMessage(error),
-        "Check the Tracker",
-      );
-    }
-    // After the Worktree, so that a hard stop at any earlier stage leaves it on
-    // disk for the Consumer to look at (ADR 0029) — and because a Branch cannot
-    // be deleted while a Worktree still has it checked out.
+    // After the success checks, so that a hard stop at any earlier stage leaves
+    // the Worktree on disk for the Consumer to look at (ADR 0029) — and before
+    // the merge, because a Branch cannot be deleted while a Worktree still has
+    // it checked out.
     try {
       await removeTicketWorktree(cwd, worktree);
       keptWorktree = undefined;
@@ -363,6 +350,24 @@ async function runWithLiveness(
         gitError === undefined
           ? "ReadyRun could not merge the Ticket's Branch into the Run Branch"
           : `ReadyRun could not merge the Ticket's Branch into the Run Branch. ${gitError}`,
+      );
+    }
+    // After the merge, because the commit the Ticket is about to name does not
+    // exist before it — and because a merge that fails must leave the Ticket on
+    // the Frontier rather than off it with nothing landed (ADR 0033).
+    const landing = { runBranch, mergeCommit: runBranchTip };
+    try {
+      if (config.leaveFrontier) {
+        await config.leaveFrontier(ticket, landing);
+      } else {
+        await config.tracker.leaveFrontier(ticket, landing);
+      }
+    } catch (error) {
+      return stop(
+        "tracker",
+        ticket.id,
+        caughtMessage(error),
+        "Check the Tracker",
       );
     }
   }

--- a/src/tracker-adapter.ts
+++ b/src/tracker-adapter.ts
@@ -22,11 +22,20 @@ export type TrackerInspect = {
   readonly canExpressBlocking: boolean;
 };
 
+// Where a finished Ticket's work went. The Run Branch and the merge commit are
+// the only durable pointers to it, since the Ticket's own Branch is deleted as
+// it merges (ADR 0028), and a Ticket that names them says nothing a Tracker
+// Adapter has to look up (ADR 0033).
+export type Landing = {
+  readonly runBranch: string;
+  readonly mergeCommit: string;
+};
+
 export type TrackerAdapter = {
   readonly [brand]: true;
   frontier(): Promise<Ticket[]>;
   branchName(ticket: Ticket): string;
-  leaveFrontier(ticket: Ticket): Promise<void>;
+  leaveFrontier(ticket: Ticket, landing: Landing): Promise<void>;
   promptCopy(ticket: Ticket): string;
   inspect(): Promise<TrackerInspect>;
 };

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -712,7 +712,7 @@ test("the check runs once at Run start, not on every iteration", async () => {
   const tracker = createTrackerAdapter({
     frontier: () => inner.frontier(),
     branchName: (ticket) => inner.branchName(ticket),
-    leaveFrontier: (ticket) => inner.leaveFrontier(ticket),
+    leaveFrontier: (ticket, landed) => inner.leaveFrontier(ticket, landed),
     promptCopy: (ticket) => inner.promptCopy(ticket),
     inspect() {
       inspects += 1;

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -712,7 +712,7 @@ test("the check runs once at Run start, not on every iteration", async () => {
   const tracker = createTrackerAdapter({
     frontier: () => inner.frontier(),
     branchName: (ticket) => inner.branchName(ticket),
-    leaveFrontier: (ticket, landed) => inner.leaveFrontier(ticket, landed),
+    leaveFrontier: (ticket, landing) => inner.leaveFrontier(ticket, landing),
     promptCopy: (ticket) => inner.promptCopy(ticket),
     inspect() {
       inspects += 1;

--- a/test/github-http-fixture.ts
+++ b/test/github-http-fixture.ts
@@ -24,6 +24,21 @@ export type GitHubHttpFixture = {
   requests: readonly GitHubRecordedRequest[];
 };
 
+// What a Consumer would read on the Ticket, in the order it was posted.
+export function postedComments(
+  fixture: GitHubHttpFixture,
+  ticketId: string,
+): string[] {
+  return fixture.requests
+    .filter((request) =>
+      request.method === "POST" &&
+      request.url.endsWith(`/issues/${ticketId}/comments`)
+    )
+    .map((request) =>
+      (JSON.parse(request.body ?? "{}") as { body?: string }).body ?? ""
+    );
+}
+
 export function githubFromWorld(
   world: MemoryTrackerOptions,
   repo = "acme/widgets",

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -4,8 +4,12 @@ import { test } from "node:test";
 import { promisify } from "node:util";
 import { defineConfig, doctor, github, run } from "../src/mod.ts";
 import { recordingWorker } from "../src/testing/mod.ts";
-import { githubFromWorld, githubHttpFixture } from "./github-http-fixture.ts";
-import { ticket } from "./tracker-adapter-contract.ts";
+import {
+  githubFromWorld,
+  githubHttpFixture,
+  postedComments,
+} from "./github-http-fixture.ts";
+import { landing, ticket } from "./tracker-adapter-contract.ts";
 import { throwawayRepo } from "./throwaway-repo.ts";
 
 const exec = promisify(execFile);
@@ -32,7 +36,7 @@ test("success drops the frontier label, comments, and does not close", async () 
   const frontier = await adapter.frontier();
   const finished = frontier[0];
   assert.ok(finished);
-  await adapter.leaveFrontier(finished);
+  await adapter.leaveFrontier(finished, landing());
 
   assert.ok(
     fixture.requests.some(
@@ -41,12 +45,9 @@ test("success drops the frontier label, comments, and does not close", async () 
         request.url.endsWith("/issues/52/labels/ready-for-agent"),
     ),
   );
-  const comments = fixture.requests.filter(
-    (request) =>
-      request.method === "POST" && request.url.endsWith("/issues/52/comments"),
-  );
+  const comments = postedComments(fixture, "52");
   assert.equal(comments.length, 1);
-  assert.match(comments[0]?.body ?? "", /left the Frontier/);
+  assert.match(comments[0] ?? "", /left the Frontier/);
   assert.equal(
     fixture.requests.filter((request) => request.method === "PATCH").length,
     0,
@@ -57,6 +58,27 @@ test("success drops the frontier label, comments, and does not close", async () 
       (request.body ?? "").includes("\"state\":\"closed\"")
     ),
   );
+});
+
+test("the comment names the Run Branch, the merge commit, and that the ref is local to the machine that ran the Run", async () => {
+  const { adapter, fixture } = githubFromWorld(world);
+  const frontier = await adapter.frontier();
+  const finished = frontier[0];
+  assert.ok(finished);
+  await adapter.leaveFrontier(
+    finished,
+    landing({
+      runBranch: "readyrun/run-20260904-143000",
+      mergeCommit: "0f1e2d3c4b5a69788796a5b4c3d2e1f009182736",
+    }),
+  );
+
+  const comment = postedComments(fixture, "52")[0] ?? "";
+  assert.match(comment, /readyrun\/run-20260904-143000/);
+  assert.match(comment, /0f1e2d3/);
+  assert.match(comment, /local to the machine that ran the Run/);
+  // A reviewer must not read the ref as somewhere they can fetch from.
+  assert.match(comment, /never pushes/);
 });
 
 test("inspect reports labels that exist on GitHub, not the selector", async () => {

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -68,14 +68,14 @@ test("the comment names the Run Branch, the merge commit, and that the ref is lo
   await adapter.leaveFrontier(
     finished,
     landing({
-      runBranch: "readyrun/run-20260904-143000",
-      mergeCommit: "0f1e2d3c4b5a69788796a5b4c3d2e1f009182736",
+      runBranch: "readyrun/run-20261102-091500",
+      mergeCommit: "9c8b7a6543210fedcba98765432100fedcba9876",
     }),
   );
 
   const comment = postedComments(fixture, "52")[0] ?? "";
-  assert.match(comment, /readyrun\/run-20260904-143000/);
-  assert.match(comment, /0f1e2d3/);
+  assert.match(comment, /readyrun\/run-20261102-091500/);
+  assert.match(comment, /9c8b7a6/);
   assert.match(comment, /local to the machine that ran the Run/);
   // A reviewer must not read the ref as somewhere they can fetch from.
   assert.match(comment, /never pushes/);

--- a/test/linear.test.ts
+++ b/test/linear.test.ts
@@ -8,7 +8,7 @@ import {
   linearHttpFixture,
   linearInReviewStateId,
 } from "./linear-http-fixture.ts";
-import { ticket } from "./tracker-adapter-contract.ts";
+import { landing, ticket } from "./tracker-adapter-contract.ts";
 import { throwawayRepo } from "./throwaway-repo.ts";
 
 const silent = { write(_chunk?: string) { return true; } };
@@ -24,7 +24,7 @@ test("success moves the Ticket to In Review and never Done", async () => {
   const frontier = await adapter.frontier();
   const finished = frontier[0];
   assert.ok(finished);
-  await adapter.leaveFrontier(finished);
+  await adapter.leaveFrontier(finished, landing());
 
   const bodies = fixture.requests.map((request) => request.body ?? "").join("\n");
   assert.match(bodies, new RegExp(linearInReviewStateId));

--- a/test/run-liveness.test.ts
+++ b/test/run-liveness.test.ts
@@ -53,7 +53,7 @@ function delayTracker(
       return inner.frontier();
     },
     branchName: (item) => inner.branchName(item),
-    leaveFrontier: (item) => inner.leaveFrontier(item),
+    leaveFrontier: (item, landed) => inner.leaveFrontier(item, landed),
     promptCopy: (item) => inner.promptCopy(item),
     async inspect() {
       if (delays.inspect !== undefined) {

--- a/test/run-liveness.test.ts
+++ b/test/run-liveness.test.ts
@@ -53,7 +53,7 @@ function delayTracker(
       return inner.frontier();
     },
     branchName: (item) => inner.branchName(item),
-    leaveFrontier: (item, landed) => inner.leaveFrontier(item, landed),
+    leaveFrontier: (item, landing) => inner.leaveFrontier(item, landing),
     promptCopy: (item) => inner.promptCopy(item),
     async inspect() {
       if (delays.inspect !== undefined) {

--- a/test/run-ticket-landing.test.ts
+++ b/test/run-ticket-landing.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { test } from "node:test";
+import { createTrackerAdapter, defineConfig, run } from "../src/mod.ts";
+import type { Landing } from "../src/mod.ts";
+import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
+import { ticket } from "./tracker-adapter-contract.ts";
+import {
+  git,
+  onDisk,
+  runBranch,
+  runBranches,
+  throwawayRepo,
+} from "./throwaway-repo.ts";
+
+const silent = { write(_chunk?: string) { return true; } };
+
+test("a Consumer's leaveFrontier override is told the Run Branch and the merge commit the Ticket landed as", async () => {
+  const repo = await throwawayRepo();
+  const told: {
+    ticketId: string;
+    landing: Landing;
+    runBranchTipWhenTold: string;
+  }[] = [];
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "52" })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+        async leaveFrontier(finished, landing) {
+          told.push({
+            ticketId: finished.id,
+            landing,
+            // Read as the Tracker is told, not afterwards: the merge commit it
+            // names has to be on the Run Branch by then.
+            runBranchTipWhenTold: await git(repo.cwd, [
+              "rev-parse",
+              `refs/heads/${landing.runBranch}`,
+            ]),
+          });
+        },
+      }),
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(exitCode, 0);
+    const collected = await runBranch(repo.cwd);
+    assert.deepEqual(told.map((call) => call.ticketId), ["52"]);
+    assert.deepEqual(told[0]?.landing, {
+      runBranch: collected,
+      mergeCommit: await git(repo.cwd, ["rev-parse", `refs/heads/${collected}`]),
+    });
+    assert.equal(told[0]?.runBranchTipWhenTold, told[0]?.landing.mergeCommit);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a merge failure leaves the Ticket on the Frontier and tells the Tracker nothing", async () => {
+  const repo = await throwawayRepo();
+  const inner = memoryTracker({
+    tickets: [ticket({ id: "52" }), ticket({ id: "57" })],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+  });
+  const told: string[] = [];
+  const chunks: string[] = [];
+  try {
+    // A branch named readyrun makes every ref under readyrun/ unwritable, so
+    // the merge fails where it writes the Run Branch. The Ticket's own Branch
+    // is named out of that collision, so the Run gets as far as the merge.
+    await git(repo.cwd, ["branch", "readyrun"]);
+
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: createTrackerAdapter({
+          frontier: () => inner.frontier(),
+          branchName: (item) => `work/${item.id}`,
+          leaveFrontier(item, landing) {
+            told.push(item.id);
+            return inner.leaveFrontier(item, landing);
+          },
+          promptCopy: (item) => inner.promptCopy(item),
+          inspect: () => inner.inspect(),
+        }),
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: {
+        write(chunk: string) {
+          chunks.push(chunk);
+          return true;
+        },
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(told, []);
+    assert.deepEqual(
+      (await inner.frontier()).map((item) => item.id),
+      ["52", "57"],
+    );
+    assert.deepEqual(await runBranches(repo.cwd), []);
+    // Gone before the merge was attempted: a Branch cannot be deleted while a
+    // Worktree still has it checked out (ADR 0029).
+    assert.equal(
+      await onDisk(join(repo.cwd, ".readyrun", "worktrees", "work-52")),
+      false,
+    );
+    const output = chunks.join("");
+    assert.match(
+      output,
+      /Hard stop: Ticket 52 failed at git: ReadyRun could not merge the Ticket's Branch into the Run Branch/,
+    );
+    assert.match(output, /0 Tickets landed; no Run Branch was created/);
+  } finally {
+    await repo.cleanup();
+  }
+});

--- a/test/run-worktree-lifetime.test.ts
+++ b/test/run-worktree-lifetime.test.ts
@@ -94,11 +94,13 @@ test("a Worker exiting 0 whose Branch tree matches the base leaves its Worktree 
   }
 });
 
-test("a Tracker failure finishing a Ticket leaves the Worktree on disk even though the Worker succeeded", async () => {
+test("a Tracker failure finishing a Ticket keeps no Worktree, because the merge it is told about already landed the work", async () => {
   const repo = await throwawayRepo();
   const inner = tracker();
   const worker = recordingWorker({ exitCode: 0 });
   try {
+    const base = await git(repo.cwd, ["rev-parse", "HEAD"]);
+
     const exitCode = await run({
       config: defineConfig({
         tracker: createTrackerAdapter({
@@ -117,7 +119,10 @@ test("a Tracker failure finishing a Ticket leaves the Worktree on disk even thou
     });
 
     assert.equal(exitCode, 1);
-    assert.equal(await onDisk(worktreeOf(repo.cwd, "52")), true);
+    assert.equal(await onDisk(worktreeOf(repo.cwd, "52")), false);
+    // Nothing to look at is lost: the Ticket the Tracker was never told about
+    // is on the Run Branch, which is what the Worktree was standing in for.
+    assert.equal((await runBranchMerges(repo.cwd, base)).length, 1);
   } finally {
     await repo.cleanup();
   }

--- a/test/tracker-adapter-contract.ts
+++ b/test/tracker-adapter-contract.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { MemoryTrackerOptions } from "../src/testing/memory-tracker.ts";
 import type { Ticket } from "../src/ticket.ts";
-import type { TrackerAdapter } from "../src/tracker-adapter.ts";
+import type { Landing, TrackerAdapter } from "../src/tracker-adapter.ts";
 
 export type TrackerContractFactory = (
   world: MemoryTrackerOptions,
@@ -17,6 +17,16 @@ export function ticket(
     url: `https://example.test/${overrides.id}`,
     labels: ["ready-for-agent"],
     blockedBy: [],
+    ...overrides,
+  };
+}
+
+// A landing as `run` reports one: the Run Branch the Ticket was collected onto
+// and the full merge commit git wrote.
+export function landing(overrides: Partial<Landing> = {}): Landing {
+  return {
+    runBranch: "readyrun/run-20260904-143000",
+    mergeCommit: "0f1e2d3c4b5a69788796a5b4c3d2e1f009182736",
     ...overrides,
   };
 }
@@ -136,7 +146,7 @@ export function trackerAdapterContract(
 
     const finished = before[0];
     assert.ok(finished);
-    await adapter.leaveFrontier(finished);
+    await adapter.leaveFrontier(finished, landing());
 
     const after = await adapter.frontier();
     assert.deepEqual(

--- a/test/tracker-adapter-factory.test.ts
+++ b/test/tracker-adapter-factory.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../src/mod.ts";
 import type { Ticket } from "../src/mod.ts";
 import { recordingWorker } from "../src/testing/mod.ts";
-import { ticket } from "./tracker-adapter-contract.ts";
+import { landing, ticket } from "./tracker-adapter-contract.ts";
 import { throwawayRepo } from "./throwaway-repo.ts";
 
 const silent = { write(_chunk?: string) { return true; } };
@@ -74,7 +74,9 @@ test("createTrackerAdapter defaults branchName, leaveFrontier, promptCopy, and i
   });
 
   assert.equal(tracker.branchName(ticket({ id: "52" })), "readyrun/52");
-  await assert.doesNotReject(() => tracker.leaveFrontier(ticket({ id: "52" })));
+  await assert.doesNotReject(() =>
+    tracker.leaveFrontier(ticket({ id: "52" }), landing())
+  );
   assert.match(tracker.promptCopy(ticket({ id: "52" })), /52/);
   const inspected = await tracker.inspect();
   assert.equal(inspected.canExpressBlocking, true);


### PR DESCRIPTION
## Why

Closes #99.

When a **Ticket** left the **Frontier**, the **Consumer** was told only that a **Worker** had succeeded. The copy was fixed and named neither the **Run Branch** nor the merge commit, so the reviewer opening that **Ticket** — the surface they are already looking at — had no pointer to the code. Since ADR 0028 deletes the **Ticket**'s own **Branch** as it merges, those two are the only durable pointers there are.

## What

`leaveFrontier` now carries the landing it reports — the **Run Branch** and the merge commit — and is called after the merge rather than before it. The GitHub comment names both and states that the ref is local to the machine that ran the **Run**, because ReadyRun never pushes and a **Ticket** naming an unfetchable ref as though it were a shared location is the silent lie ADR 0009 and ADR 0029 exist to refuse.

## How

Widening an interface published through `createTrackerAdapter` (ADR 0025) is free before 1.0 and a breaking change after, which is why it lands now. Moving the call after the merge also closes a window in which a merge failure left a **Ticket** off the **Frontier** with nothing landed.

## Workarounds

A **Tracker** failure finishing a **Ticket** no longer keeps the **Worktree**: it must be removed before the merge, since a **Branch** cannot be deleted while a **Worktree** has it checked out, and the merge it is being told about has already put that work on the **Run Branch**. The one stage where that leaves nothing to look at is a merge failure itself, raised separately as #104.

Linear has no comment to extend yet and is out of scope per #100.

Made with [Cursor](https://cursor.com)