### PR TITLE
Post Linear's landing comment on finish (#100)

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@readyrun/readyrun",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "exports": {
     ".": "./src/mod.ts",
     "./cli": "./src/cli.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readyrun/readyrun",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@readyrun/readyrun",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readyrun/readyrun",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Walk a tracker Frontier and run one coding Worker per Ticket.",
   "license": "MIT",
   "type": "module",

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -1,11 +1,10 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { landingComment } from "../landing-comment.ts";
 import {
   createTrackerAdapter,
-  type Landing,
   type TrackerAdapter,
 } from "../tracker-adapter.ts";
-import { shortCommit } from "../git.ts";
 import type { Ticket } from "../ticket.ts";
 import { assertKnownKeys } from "../unknown-keys.ts";
 
@@ -290,20 +289,6 @@ export function github(
     }),
     { options },
   );
-}
-
-// The Ticket's own Branch is gone by the time this is written (ADR 0028), so
-// the Run Branch and the merge commit are the only pointers a reviewer has —
-// and the ref is disclosed as local, because ReadyRun never pushes and a Ticket
-// naming an unfetchable ref as though it were shared is a lie (ADR 0033).
-function landingComment(landing: Landing): string {
-  return [
-    "ReadyRun: this Ticket left the Frontier after a successful Worker.",
-    "",
-    `The work landed on the Run Branch \`${landing.runBranch}\` as merge commit \`${
-      shortCommit(landing.mergeCommit)
-    }\`. That ref is local to the machine that ran the Run — ReadyRun never pushes, so it cannot be fetched from anywhere else.`,
-  ].join("\n");
 }
 
 function matchesFrontier(

--- a/src/adapters/linear.ts
+++ b/src/adapters/linear.ts
@@ -1,3 +1,4 @@
+import { landingComment } from "../landing-comment.ts";
 import {
   createTrackerAdapter,
   type TrackerAdapter,
@@ -131,6 +132,13 @@ const leaveFrontierMutation = `mutation LeaveFrontier($id: String!, $input: Issu
   issueUpdate(id: $id, input: $input) {
     success
     issue { identifier state { name type } }
+  }
+}`;
+
+const commentCreateMutation = `mutation CommentCreate($input: CommentCreateInput!) {
+  commentCreate(input: $input) {
+    success
+    comment { id }
   }
 }`;
 
@@ -302,7 +310,7 @@ export function linear(
       branchName(ticket) {
         return suggestedBranches.get(ticket.id) ?? `readyrun/${ticket.id}`;
       },
-      async leaveFrontier(ticket) {
+      async leaveFrontier(ticket, landing) {
         const data = await graphql<IssueStatesData>(
           "IssueStates",
           issueStatesQuery,
@@ -321,6 +329,9 @@ export function linear(
         await graphql("LeaveFrontier", leaveFrontierMutation, {
           id: ticket.id,
           input: { stateId: inReview.id },
+        });
+        await graphql("CommentCreate", commentCreateMutation, {
+          input: { issueId: ticket.id, body: landingComment(landing) },
         });
       },
       promptCopy(ticket) {

--- a/src/landing-comment.ts
+++ b/src/landing-comment.ts
@@ -1,0 +1,16 @@
+import { shortCommit } from "./git.ts";
+import type { Landing } from "./tracker-adapter.ts";
+
+// The Ticket's own Branch is gone by the time this is written (ADR 0028), so
+// the Run Branch and the merge commit are the only pointers a reviewer has —
+// and the ref is disclosed as local, because ReadyRun never pushes and a Ticket
+// naming an unfetchable ref as though it were shared is a lie (ADR 0033).
+export function landingComment(landing: Landing): string {
+  return [
+    "ReadyRun: this Ticket left the Frontier after a successful Worker.",
+    "",
+    `The work landed on the Run Branch \`${landing.runBranch}\` as merge commit \`${
+      shortCommit(landing.mergeCommit)
+    }\`. That ref is local to the machine that ran the Run — ReadyRun never pushes, so it cannot be fetched from anywhere else.`,
+  ].join("\n");
+}

--- a/test/linear-http-fixture.ts
+++ b/test/linear-http-fixture.ts
@@ -60,6 +60,28 @@ const doneState: FixtureState = {
 export const linearInReviewStateId = inReviewState.id;
 export const linearDoneStateId = doneState.id;
 
+// What a Consumer would read on the Ticket, in the order it was posted.
+export function postedComments(
+  fixture: LinearHttpFixture,
+  ticketId: string,
+): string[] {
+  return fixture.requests.flatMap((request) => {
+    const parsed = request.body === undefined
+      ? undefined
+      : JSON.parse(request.body) as {
+        operationName?: string;
+        variables?: { input?: { issueId?: string; body?: string } };
+      };
+    if (
+      parsed?.operationName !== "CommentCreate" ||
+      parsed.variables?.input?.issueId !== ticketId
+    ) {
+      return [];
+    }
+    return [parsed.variables.input.body ?? ""];
+  });
+}
+
 export function linearFromWorld(
   world: LinearWorld,
 ): { adapter: ReturnType<typeof linear>; fixture: LinearHttpFixture } {
@@ -208,7 +230,7 @@ function graphqlResponse(
       variables?: {
         id?: string;
         cursor?: string;
-        input?: { stateId?: string };
+        input?: { stateId?: string; issueId?: string; body?: string };
       };
     };
   const operation = parsed.operationName ?? "";
@@ -305,6 +327,24 @@ function graphqlResponse(
                   "started",
               },
             },
+        },
+      },
+    }, 200);
+  }
+
+  if (operation === "CommentCreate") {
+    const issueId = variables.input?.issueId;
+    const issue = issues.find((candidate) => candidate.identifier === issueId);
+    if (issue === undefined) {
+      return jsonResponse({
+        errors: [{ message: `Linear Ticket ${issueId} was not found` }],
+      }, 200);
+    }
+    return jsonResponse({
+      data: {
+        commentCreate: {
+          success: true,
+          comment: { id: "comment-1" },
         },
       },
     }, 200);

--- a/test/linear.test.ts
+++ b/test/linear.test.ts
@@ -7,6 +7,7 @@ import {
   linearFromWorld,
   linearHttpFixture,
   linearInReviewStateId,
+  postedComments,
 } from "./linear-http-fixture.ts";
 import { landing, ticket } from "./tracker-adapter-contract.ts";
 import { throwawayRepo } from "./throwaway-repo.ts";
@@ -35,6 +36,66 @@ test("success moves the Ticket to In Review and never Done", async () => {
     ),
     false,
   );
+  assert.equal(postedComments(fixture, "52").length, 1);
+});
+
+test("the comment names the Run Branch, the merge commit, and that the ref is local to the machine that ran the Run", async () => {
+  const { adapter, fixture } = linearFromWorld(world);
+  const frontier = await adapter.frontier();
+  const finished = frontier[0];
+  assert.ok(finished);
+  await adapter.leaveFrontier(
+    finished,
+    landing({
+      runBranch: "readyrun/run-20261102-091500",
+      mergeCommit: "9c8b7a6543210fedcba98765432100fedcba9876",
+    }),
+  );
+
+  assert.equal(
+    postedComments(fixture, "52")[0],
+    [
+      "ReadyRun: this Ticket left the Frontier after a successful Worker.",
+      "",
+      "The work landed on the Run Branch `readyrun/run-20261102-091500` as merge commit `9c8b7a6`. That ref is local to the machine that ran the Run — ReadyRun never pushes, so it cannot be fetched from anywhere else.",
+    ].join("\n"),
+  );
+});
+
+test("a comment failure is a Tracker failure, not a quiet continue", async () => {
+  const fixture = linearHttpFixture(world);
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const body = typeof init?.body === "string" ? init.body : undefined;
+    const operation = body === undefined
+      ? undefined
+      : (JSON.parse(body) as { operationName?: string }).operationName;
+    if (operation === "CommentCreate") {
+      return new Response(
+        JSON.stringify({ errors: [{ message: "Comment create failed" }] }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    return fixture.fetch(input, init);
+  };
+  const adapter = linear(
+    { ready: "unblocked", label: "ready-for-agent" },
+    { token: "test-token", fetch: fetchImpl },
+  );
+  const frontier = await adapter.frontier();
+  const finished = frontier[0];
+  assert.ok(finished);
+  await assert.rejects(
+    () => adapter.leaveFrontier(finished, landing()),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /could not reach Linear/);
+      assert.match(error.message, /Comment create failed/);
+      return true;
+    },
+  );
+  const bodies = fixture.requests.map((request) => request.body ?? "").join("\n");
+  assert.match(bodies, new RegExp(linearInReviewStateId));
+  assert.equal(bodies.includes(linearDoneStateId), false);
 });
 
 test("when Linear exposes a suggested branch name, that is the Branch", async () => {


### PR DESCRIPTION
## Why

Closes #100.

Linear's finish transition moved the **Ticket** to In Review and said nothing else. A Linear **Consumer** got the state change with no pointer to the code — Trackunit is a real v0 **Consumer** on Linear, so leaving the handoff to GitHub alone meant ADR 0033 existed for only one of the two **Trackers**.

## What

Linear's default `leaveFrontier` now posts a comment naming the **Run Branch**, the merge commit, and that the ref is local to the machine that ran the **Run**. The In Review transition is unchanged and the **Ticket** is still never marked Done. A comment failure is a **Tracker** failure, so a **Run** hard-stops rather than continuing quietly.

## How

Both adapters share the same landing copy, so the two **Consumers** get the same handoff. Linear posts it with `commentCreate` after the existing In Review `issueUpdate`.


Made with [Cursor](https://cursor.com)