### PR TITLE
Continue a capped Run from its Run Branch with --base (#107)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ readyrun doctor
 readyrun run --max 5
 ```
 
+A **Run** cuts every **Worktree** from your checkout unless `--base <commit-ish>` names another commit; either way it leaves your checkout where it is. Hitting the cap ends a **Run**, so carrying on is a *new* **Run** based on the **Run Branch** the last one built ([ADR 0034](./docs/adr/0034-continuing-a-capped-run-is-a-new-run-with-an-explicit-base.md)) — and a cap stop prints that command, so there is no timestamp to remember:
+
+```
+Run complete: cap of 2 Tickets reached; the Frontier may still hold work
+2 Tickets landed on readyrun/run-20260904-152033, cut from 68a6987.
+Continue with: readyrun run --max 2 --base readyrun/run-20260904-152033
+```
+
 JSR does not put `readyrun` on PATH. Run the `cli` export as a program (Deno):
 
 ```sh

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@ const usage = `Usage: readyrun <command>
 
 Commands:
   init [--answers <file>]
-  run --max <n> [--model <id>] [--permissions ask|unattended] [--effort low|medium|high|xhigh|max]
+  run --max <n> [--base <commit-ish>] [--model <id>] [--permissions ask|unattended] [--effort low|medium|high|xhigh|max]
   doctor
 
 A Run cannot start without a cap.
@@ -100,6 +100,7 @@ export type CliOptions = {
 
 type RunFlags = {
   cap?: number;
+  base?: string;
   permissions?: Permissions;
   model?: string;
   effort?: Effort;
@@ -109,6 +110,7 @@ function parseRunFlags(args: string[]):
   | ({ ok: true } & RunFlags)
   | { ok: false; message: string } {
   let cap: number | undefined;
+  let base: string | undefined;
   let permissions: Permissions | undefined;
   let model: string | undefined;
   let effort: Effort | undefined;
@@ -118,6 +120,13 @@ function parseRunFlags(args: string[]):
     if (arg === "--max") {
       sawMax = true;
       cap = Number(args[i + 1]);
+      i += 1;
+    } else if (arg === "--base") {
+      const value = args[i + 1];
+      if (value === undefined || value.length === 0) {
+        return { ok: false, message: "--base requires a commit-ish" };
+      }
+      base = value;
       i += 1;
     } else if (arg === "--permissions") {
       const value = args[i + 1];
@@ -144,7 +153,7 @@ function parseRunFlags(args: string[]):
   if (sawMax && (cap === undefined || !Number.isInteger(cap) || cap < 1)) {
     return { ok: false, message: "A Run cannot start without a cap" };
   }
-  return { ok: true, cap, permissions, model, effort };
+  return { ok: true, cap, base, permissions, model, effort };
 }
 
 function parseInitFlags(args: string[]):
@@ -236,6 +245,7 @@ export async function cli(options: CliOptions): Promise<number> {
       return await invoke({
         config,
         cap: runFlags.cap,
+        base: runFlags.base,
         cwd,
         stdout,
         permissions: runFlags.permissions,

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -116,6 +116,12 @@ function workerBinaryExists(bin: string): boolean {
 
 function baseLine(base: RunBase): string {
   const commit = shortCommit(base.commit);
+  // The default-branch callout exists to catch a base nobody meant. A base the
+  // Consumer named was meant, so it is attributed to the flag and measured
+  // against nothing (ADR 0034).
+  if (base.named !== undefined) {
+    return `Base: ${commit} from --base ${base.named}`;
+  }
   // A detached checkout is on no branch, so it is named the default branch
   // rather than told it differs from one: the base may well be that branch's
   // own tip.

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -116,11 +116,8 @@ function workerBinaryExists(bin: string): boolean {
 
 function baseLine(base: RunBase): string {
   const commit = shortCommit(base.commit);
-  // The default-branch callout exists to catch a base nobody meant. A base the
-  // Consumer named was meant, so it is attributed to the flag and measured
-  // against nothing (ADR 0034).
-  if (base.named !== undefined) {
-    return `Base: ${commit} from --base ${base.named}`;
+  if (base.kind === "commit-ish") {
+    return `Base: ${commit} from --base ${base.commitish}`;
   }
   // A detached checkout is on no branch, so it is named the default branch
   // rather than told it differs from one: the base may well be that branch's

--- a/src/git.ts
+++ b/src/git.ts
@@ -178,19 +178,30 @@ export class BaseNotFoundError extends Error {
   }
 }
 
-export type RunBase = {
+// Where a base came from, which decides what a Consumer needs told about it. A
+// checkout is measured against the default branch, because a base nobody meant
+// is usually one they were standing on without noticing; a commit-ish they
+// typed was meant, so it is attributed to the flag and measured against nothing
+// (ADR 0034). The default branch is therefore a fact about a checkout rather
+// than about every base.
+type CheckoutBase = {
+  kind: "checkout";
   commit: string;
   // Undefined on a detached checkout, which is a base without a branch rather
-  // than a branch named HEAD — and on a named base, which is a commit rather
-  // than somewhere the Consumer is standing, even when the commit-ish they
-  // typed happens to be a branch.
+  // than a branch named HEAD.
   branch: string | undefined;
   defaultBranch: string;
-  dirty: boolean;
-  // The commit-ish `--base` named, absent when the base is the checkout's own
-  // HEAD.
-  named?: string;
 };
+
+type CommitishBase = {
+  kind: "commit-ish";
+  commit: string;
+  commitish: string;
+};
+
+// Dirty belongs to neither: it is the primary checkout's tree either way, since
+// that is the work reaching no Worktree whichever commit the Run builds on.
+export type RunBase = (CheckoutBase | CommitishBase) & { dirty: boolean };
 
 // How a commit is named to a Consumer, wherever one is named: the base a Run
 // discloses at start and the base its report says the Run Branch was cut from
@@ -200,40 +211,41 @@ export function shortCommit(commit: string): string {
 }
 
 // One read of what a Run starts from: the commit every Worktree is cut from,
-// plus what a Consumer cannot see from that commit alone — that the base is not
-// the default branch, and that uncommitted work in the primary checkout reaches
-// no Worktree. The commit is read first, so nothing to branch from fails before
-// anything else is read.
-//
-// A named commit-ish is resolved instead of HEAD and never moves the checkout,
-// so continuing a capped Run does not require that checkout to have been clean
-// (ADR 0034). The dirty read is still the primary checkout's, because that is
-// the tree whose uncommitted work is being left behind either way.
+// plus what a Consumer cannot see from that commit alone. A commit-ish is
+// resolved instead of HEAD and the checkout is never moved, so continuing a
+// capped Run does not require that checkout to have been clean (ADR 0034) —
+// but the dirty read is still the primary checkout's either way, because that
+// is the tree whose uncommitted work reaches no Worktree.
 export async function resolveRunBase(
   cwd: string,
-  named?: string,
+  commitish?: string,
 ): Promise<RunBase> {
-  if (named !== undefined) {
-    return {
-      commit: await resolveCommitish(cwd, named),
-      branch: undefined,
-      named,
-      defaultBranch: await defaultBranch(cwd),
-      dirty: !await worktreeIsClean(cwd),
+  const from: CheckoutBase | CommitishBase = commitish === undefined
+    ? await resolveCheckoutBase(cwd)
+    : {
+      kind: "commit-ish",
+      commit: await resolveCommitish(cwd, commitish),
+      commitish,
     };
-  }
+  return { ...from, dirty: !await worktreeIsClean(cwd) };
+}
+
+// The commit is read first, so a checkout with nothing to branch from fails
+// before anything else is read.
+async function resolveCheckoutBase(cwd: string): Promise<CheckoutBase> {
   const commit = await headCommit(cwd);
   const branch = await git(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]);
   return {
+    kind: "checkout",
     commit,
     branch: branch === "HEAD" ? undefined : branch,
     defaultBranch: await defaultBranch(cwd),
-    dirty: !await worktreeIsClean(cwd),
   };
 }
 
 // `^{commit}` so a tag resolves to what it points at and a tree or a blob is
-// not mistaken for a base.
+// not mistaken for a base; `--end-of-options` so a commit-ish that starts with
+// a dash fails as an unresolvable base rather than as a rev-parse flag.
 async function resolveCommitish(cwd: string, commitish: string): Promise<string> {
   try {
     return await git(cwd, [

--- a/src/git.ts
+++ b/src/git.ts
@@ -169,13 +169,27 @@ function execExitCode(error: unknown): number | undefined {
   return undefined;
 }
 
+export class BaseNotFoundError extends Error {
+  constructor(commitish: string) {
+    super(
+      `ReadyRun cannot resolve --base ${commitish} to a commit in this checkout`,
+    );
+    this.name = "BaseNotFoundError";
+  }
+}
+
 export type RunBase = {
   commit: string;
   // Undefined on a detached checkout, which is a base without a branch rather
-  // than a branch named HEAD.
+  // than a branch named HEAD — and on a named base, which is a commit rather
+  // than somewhere the Consumer is standing, even when the commit-ish they
+  // typed happens to be a branch.
   branch: string | undefined;
   defaultBranch: string;
   dirty: boolean;
+  // The commit-ish `--base` named, absent when the base is the checkout's own
+  // HEAD.
+  named?: string;
 };
 
 // How a commit is named to a Consumer, wherever one is named: the base a Run
@@ -185,12 +199,29 @@ export function shortCommit(commit: string): string {
   return commit.slice(0, 7);
 }
 
-// One read of the checkout a Run starts from: the commit every Worktree is cut
-// from, plus what a Consumer cannot see from that commit alone — that the base
-// is not the default branch, and that uncommitted work here reaches no
-// Worktree. The commit is read first, so a checkout with nothing to branch from
-// fails before anything else is read.
-export async function resolveRunBase(cwd: string): Promise<RunBase> {
+// One read of what a Run starts from: the commit every Worktree is cut from,
+// plus what a Consumer cannot see from that commit alone — that the base is not
+// the default branch, and that uncommitted work in the primary checkout reaches
+// no Worktree. The commit is read first, so nothing to branch from fails before
+// anything else is read.
+//
+// A named commit-ish is resolved instead of HEAD and never moves the checkout,
+// so continuing a capped Run does not require that checkout to have been clean
+// (ADR 0034). The dirty read is still the primary checkout's, because that is
+// the tree whose uncommitted work is being left behind either way.
+export async function resolveRunBase(
+  cwd: string,
+  named?: string,
+): Promise<RunBase> {
+  if (named !== undefined) {
+    return {
+      commit: await resolveCommitish(cwd, named),
+      branch: undefined,
+      named,
+      defaultBranch: await defaultBranch(cwd),
+      dirty: !await worktreeIsClean(cwd),
+    };
+  }
   const commit = await headCommit(cwd);
   const branch = await git(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]);
   return {
@@ -199,6 +230,21 @@ export async function resolveRunBase(cwd: string): Promise<RunBase> {
     defaultBranch: await defaultBranch(cwd),
     dirty: !await worktreeIsClean(cwd),
   };
+}
+
+// `^{commit}` so a tag resolves to what it points at and a tree or a blob is
+// not mistaken for a base.
+async function resolveCommitish(cwd: string, commitish: string): Promise<string> {
+  try {
+    return await git(cwd, [
+      "rev-parse",
+      "--verify",
+      "--end-of-options",
+      `${commitish}^{commit}`,
+    ]);
+  } catch {
+    throw new BaseNotFoundError(commitish);
+  }
 }
 
 // Read the Branch ref, not the Worktree's HEAD: a Worker that committed

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -6,7 +6,12 @@ export { init } from "./init.ts";
 export type { InitAnswers, InitOptions } from "./init.ts";
 export { run, RunCapRequiredError } from "./run.ts";
 export type { RunOptions } from "./run.ts";
-export { DefaultBranchError, WorktreeExistsError, WorktreeInstallError } from "./git.ts";
+export {
+  BaseNotFoundError,
+  DefaultBranchError,
+  WorktreeExistsError,
+  WorktreeInstallError,
+} from "./git.ts";
 export type { Ticket } from "./ticket.ts";
 export { createTrackerAdapter } from "./tracker-adapter.ts";
 export type { Landing, TrackerAdapter, TrackerInspect } from "./tracker-adapter.ts";

--- a/src/run.ts
+++ b/src/run.ts
@@ -21,6 +21,11 @@ type RunStdout = LivenessStdout;
 export type RunOptions = {
   config: ReadyRunConfig;
   cap?: number;
+  // The commit-ish every Worktree is cut from, and what the Run Branch
+  // collects onto. Defaults to the Consumer's checkout; naming the previous
+  // Run Branch is how a capped Run is continued (ADR 0034). There is no config
+  // key for it, because a permanently overridden base is nobody's workflow.
+  base?: string;
   cwd?: string;
   stdout?: RunStdout;
   model?: string;
@@ -96,6 +101,17 @@ function caughtMessage(error: unknown): string | undefined {
   return error instanceof Error ? error.message : undefined;
 }
 
+// A Worker writes to the inherited descriptor rather than through ReadyRun, so
+// ReadyRun cannot know whether the last byte on the stream was a newline. Two
+// newlines both close a line a Worker left open and leave a blank one above, so
+// a report reads as the Run's closing statement rather than as more Worker
+// output. Shared by both reports, whose symmetry is deliberate (ADR 0033), and
+// whitespace throughout, because off a TTY the output carries no escapes
+// (ADR 0032).
+function separateReport(stdout: RunStdout): void {
+  stdout.write("\n\n");
+}
+
 function hardStop(
   stdout: RunStdout,
   stage: HardStopStage,
@@ -109,12 +125,31 @@ function hardStop(
   const ticketPrefix = ticketId === undefined ? "" : `Ticket ${ticketId} `;
   const suffix = detail === undefined ? "" : `: ${detail}`;
   const action = nextAction === undefined ? "" : `. ${nextAction}`;
+  separateReport(stdout);
   stdout.write(`Hard stop: ${ticketPrefix}failed at ${stage}${suffix}${action}\n`);
   stdout.write(`${landingLine(landed, runBranch)}\n`);
   if (worktree !== undefined) {
     stdout.write(`Worktree kept at ${worktree}\n`);
   }
   return 1;
+}
+
+// Only where the cap is what stopped the Run and there is a Run Branch to
+// continue from: an empty Frontier has nothing left to continue to, and a Run
+// that landed nothing created no ref to name (ADR 0034). The cap carried is the
+// one the Consumer just used, so continuing is the same slice again — and it is
+// ReadyRun's own next invocation, which declining to own integration does not
+// stop it recommending (ADR 0033).
+function continueLine(
+  reason: CleanStop,
+  cap: number,
+  landed: number,
+  runBranch: string,
+): string | undefined {
+  if (reason !== "cap" || landed === 0) {
+    return undefined;
+  }
+  return `Continue with: readyrun run --max ${cap} --base ${runBranch}`;
 }
 
 // A clean stop leaves a Consumer with the question the hard-stop report already
@@ -130,6 +165,7 @@ function completionReport(
   runBranch: string,
   base: string,
 ): 0 {
+  separateReport(stdout);
   stdout.write(
     reason === "frontier-empty"
       ? "Run complete: the Frontier is empty\n"
@@ -138,6 +174,10 @@ function completionReport(
       } reached; the Frontier may still hold work\n`,
   );
   stdout.write(`${landingLine(landed, runBranch, base)}\n`);
+  const carryOn = continueLine(reason, cap, landed, runBranch);
+  if (carryOn !== undefined) {
+    stdout.write(`${carryOn}\n`);
+  }
   return 0;
 }
 
@@ -200,7 +240,7 @@ async function runWithLiveness(
   };
   let base;
   try {
-    base = await resolveRunBase(cwd);
+    base = await resolveRunBase(cwd, options.base);
   } catch (error) {
     return stop(
       "git",

--- a/src/run.ts
+++ b/src/run.ts
@@ -134,29 +134,19 @@ function hardStop(
   return 1;
 }
 
-// Only where the cap is what stopped the Run and there is a Run Branch to
-// continue from: an empty Frontier has nothing left to continue to, and a Run
-// that landed nothing created no ref to name (ADR 0034). The cap carried is the
-// one the Consumer just used, so continuing is the same slice again — and it is
-// ReadyRun's own next invocation, which declining to own integration does not
-// stop it recommending (ADR 0033).
-function continueLine(
-  reason: CleanStop,
-  cap: number,
-  landed: number,
-  runBranch: string,
-): string | undefined {
-  if (reason !== "cap" || landed === 0) {
-    return undefined;
-  }
-  return `Continue with: readyrun run --max ${cap} --base ${runBranch}`;
-}
-
 // A clean stop leaves a Consumer with the question the hard-stop report already
 // answers — how many Tickets landed, and whether the Run Branch ref exists —
 // plus the two a hard stop has no room for: the base and why the Run stopped.
 // It prescribes no push and no merge, because ReadyRun cannot decline to own
 // integration and then recommend a workflow for it (ADR 0033).
+//
+// The cap is the only stop worth continuing from, and it hangs off the same
+// distinction the reason already draws: an empty Frontier has nothing left to
+// continue to. The cap carried is the one the Consumer just used, so continuing
+// is the same slice again — and it is ReadyRun's own next invocation, which
+// declining to own integration does not stop it explaining (ADR 0034). The
+// landing is what the base must be, so the line waits on a Run Branch existing
+// rather than on the cap alone.
 function completionReport(
   stdout: RunStdout,
   reason: CleanStop,
@@ -174,9 +164,8 @@ function completionReport(
       } reached; the Frontier may still hold work\n`,
   );
   stdout.write(`${landingLine(landed, runBranch, base)}\n`);
-  const carryOn = continueLine(reason, cap, landed, runBranch);
-  if (carryOn !== undefined) {
-    stdout.write(`${carryOn}\n`);
+  if (reason === "cap" && landed > 0) {
+    stdout.write(`Continue with: readyrun run --max ${cap} --base ${runBranch}\n`);
   }
   return 0;
 }

--- a/test/base-disclosure.test.ts
+++ b/test/base-disclosure.test.ts
@@ -5,7 +5,7 @@ import { test } from "node:test";
 import { defineConfig, doctor, run } from "../src/mod.ts";
 import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
 import { ticket } from "./tracker-adapter-contract.ts";
-import { git, runBranch, runBranches, throwawayRepo } from "./throwaway-repo.ts";
+import { commitRepoFiles, git, runBranch, runBranches, throwawayRepo } from "./throwaway-repo.ts";
 
 const dirtyWarning =
   "Warning: uncommitted changes in the primary checkout reach no Worktree";
@@ -65,6 +65,7 @@ test("a Run names the base commit and the Run Branch before it claims a Ticket, 
       `1 Ticket landed on ${await runBranch(repo.cwd)}, cut from ${
         base.slice(0, 7)
       }.`,
+      `Continue with: readyrun run --max 1 --base ${await runBranch(repo.cwd)}`,
     ]);
   } finally {
     await repo.cleanup();
@@ -188,7 +189,59 @@ test("Doctor and a Run disclose a dirty, non-default base in the same words", as
       `1 Ticket landed on ${await runBranch(repo.cwd)}, cut from ${
         base.slice(0, 7)
       }.`,
+      `Continue with: readyrun run --max 1 --base ${await runBranch(repo.cwd)}`,
     ]);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a base named by --base is disclosed as that commit, attributed to the flag rather than to a branch the Consumer is not on", async () => {
+  const repo = await throwawayRepo();
+  const out = capturing();
+  try {
+    await git(repo.cwd, ["checkout", "-b", "side"]);
+    await commitRepoFiles(repo.cwd, { "side.txt": "off the default branch\n" });
+    const base = await git(repo.cwd, ["rev-parse", "HEAD"]);
+    await git(repo.cwd, ["checkout", "main"]);
+
+    const exitCode = await run({
+      config: config(),
+      cap: 1,
+      base: "side",
+      cwd: repo.cwd,
+      stdout: out.stdout,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.ok(
+      lines(out.chunks).includes(`Base: ${base.slice(0, 7)} from --base side`),
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+// The callout exists to catch a base nobody meant. A base the Consumer typed
+// was meant, so measuring it against the default branch is noise.
+test("a base named by --base is not called out for differing from the default branch", async () => {
+  const repo = await throwawayRepo();
+  const out = capturing();
+  try {
+    await git(repo.cwd, ["checkout", "-b", "side"]);
+    await commitRepoFiles(repo.cwd, { "side.txt": "off the default branch\n" });
+    await git(repo.cwd, ["checkout", "main"]);
+
+    const exitCode = await run({
+      config: config(),
+      cap: 1,
+      base: "side",
+      cwd: repo.cwd,
+      stdout: out.stdout,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.doesNotMatch(out.chunks.join(""), /not the default branch/);
   } finally {
     await repo.cleanup();
   }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -70,6 +70,7 @@ test("bare readyrun prints usage rather than opening a menu", async () => {
   assert.match(output, /Usage: readyrun/);
   assert.match(output, /init/);
   assert.match(output, /run --max/);
+  assert.match(output, /--base <commit-ish>/);
   assert.match(output, /doctor/);
   assert.doesNotMatch(output, /menu|wizard|select/i);
   assert.equal(exitCode, 1);
@@ -182,6 +183,51 @@ test("Effort must be low, medium, high, xhigh, or max", async () => {
   });
   assert.equal(exitCode, 1);
   assert.match(chunks.join(""), /Effort must be low, medium, high, xhigh, or max/);
+});
+
+test("--base hands the Run a base to cut from instead of the checkout", async () => {
+  const received: RunOptions[] = [];
+  await cli({
+    argv: ["run", "--max", "1", "--base", "readyrun/run-20260904-152033"],
+    stdout: silent,
+    loadConfig: async () => config,
+    run: async (options) => {
+      received.push(options);
+      return 0;
+    },
+  });
+  assert.equal(received[0]?.base, "readyrun/run-20260904-152033");
+});
+
+test("a Run without --base leaves the base to the checkout", async () => {
+  const received: RunOptions[] = [];
+  await cli({
+    argv: ["run", "--max", "1"],
+    stdout: silent,
+    loadConfig: async () => config,
+    run: async (options) => {
+      received.push(options);
+      return 0;
+    },
+  });
+  assert.equal(received[0]?.base, undefined);
+});
+
+test("--base without a commit-ish is refused rather than passed on empty", async () => {
+  const chunks: string[] = [];
+  const exitCode = await cli({
+    argv: ["run", "--max", "1", "--base"],
+    stdout: {
+      write(chunk: string) {
+        chunks.push(chunk);
+        return true;
+      },
+    },
+    loadConfig: async () => config,
+    run: async () => 0,
+  });
+  assert.equal(exitCode, 1);
+  assert.match(chunks.join(""), /--base requires a commit-ish/);
 });
 
 test("--model overrides the config default for this Run", async () => {

--- a/test/run-completion-report.test.ts
+++ b/test/run-completion-report.test.ts
@@ -22,10 +22,13 @@ function lines(chunks: string[]): string[] {
   return chunks.join("").split("\n").filter(Boolean);
 }
 
-// The report is the last two lines a Run writes: the stop reason, then the
-// landing.
+// Everything a Run writes once its last Ticket is behind it: the stop reason,
+// the landing, and — on a cap that landed work — how to continue.
 function reportLines(chunks: string[]): string[] {
-  return lines(chunks).slice(-2);
+  const all = lines(chunks);
+  const start = all.findIndex((line) => line.startsWith("Run complete:"));
+  assert.notEqual(start, -1, "a clean stop writes a Run complete line");
+  return all.slice(start);
 }
 
 test("a Run that empties the Frontier reports the Tickets it landed, the Run Branch it collected them onto, the base it was cut from, and the empty Frontier", async () => {
@@ -53,6 +56,7 @@ test("a Run that empties the Frontier reports the Tickets it landed, the Run Bra
     });
 
     assert.equal(exitCode, 0);
+    // Nothing remains on the Frontier, so there is nothing to continue to.
     assert.deepEqual(reportLines(out.chunks), [
       "Run complete: the Frontier is empty",
       `2 Tickets landed on ${await runBranch(repo.cwd)}, cut from ${
@@ -94,7 +98,81 @@ test("a Run that stops on the cap names the cap as the reason, so it is clear th
       `1 Ticket landed on ${await runBranch(repo.cwd)}, cut from ${
         base.slice(0, 7)
       }.`,
+      `Continue with: readyrun run --max 1 --base ${await runBranch(repo.cwd)}`,
     ]);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+// A cap exists so a Consumer can slice a Frontier, which makes the next Run the
+// common path (ADR 0034). Naming it is the one thing a Run says about what to
+// do next, and it is ReadyRun's own invocation rather than a git workflow.
+test("a Run that stops on the cap names the invocation that continues from the Run Branch it just built", async () => {
+  const repo = await throwawayRepo();
+  const out = capturing();
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [
+            ticket({ id: "52" }),
+            ticket({ id: "57" }),
+            ticket({ id: "70" }),
+          ],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cap: 2,
+      cwd: repo.cwd,
+      stdout: out.stdout,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(
+      reportLines(out.chunks).at(-1),
+      `Continue with: readyrun run --max 2 --base ${await runBranch(repo.cwd)}`,
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+// A cap of 0 is the only way to stop on the cap having landed nothing, and it
+// is the report seam this pins: there is no Run Branch to continue from, so
+// there is no command to name and no ref git can be asked for.
+test("a cap stop that landed nothing names no continue invocation and no Run Branch ref", async () => {
+  const repo = await throwawayRepo();
+  const out = capturing();
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: memoryTracker({
+          tickets: [ticket({ id: "52" })],
+          ready: "unblocked",
+          labels: ["ready-for-agent"],
+        }),
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cap: 0,
+      cwd: repo.cwd,
+      stdout: out.stdout,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(await runBranches(repo.cwd), []);
+    assert.deepEqual(reportLines(out.chunks), [
+      "Run complete: cap of 0 Tickets reached; the Frontier may still hold work",
+      "0 Tickets landed; no Run Branch was created.",
+    ]);
+    assert.equal(
+      lines(out.chunks).filter((line) => line.includes("readyrun/run-")).length,
+      1,
+    );
   } finally {
     await repo.cleanup();
   }

--- a/test/run-completion-report.test.ts
+++ b/test/run-completion-report.test.ts
@@ -141,43 +141,6 @@ test("a Run that stops on the cap names the invocation that continues from the R
   }
 });
 
-// A cap of 0 is the only way to stop on the cap having landed nothing, and it
-// is the report seam this pins: there is no Run Branch to continue from, so
-// there is no command to name and no ref git can be asked for.
-test("a cap stop that landed nothing names no continue invocation and no Run Branch ref", async () => {
-  const repo = await throwawayRepo();
-  const out = capturing();
-  try {
-    const exitCode = await run({
-      config: defineConfig({
-        tracker: memoryTracker({
-          tickets: [ticket({ id: "52" })],
-          ready: "unblocked",
-          labels: ["ready-for-agent"],
-        }),
-        worker: recordingWorker({ exitCode: 0 }),
-        model: "composer-2",
-      }),
-      cap: 0,
-      cwd: repo.cwd,
-      stdout: out.stdout,
-    });
-
-    assert.equal(exitCode, 0);
-    assert.deepEqual(await runBranches(repo.cwd), []);
-    assert.deepEqual(reportLines(out.chunks), [
-      "Run complete: cap of 0 Tickets reached; the Frontier may still hold work",
-      "0 Tickets landed; no Run Branch was created.",
-    ]);
-    assert.equal(
-      lines(out.chunks).filter((line) => line.includes("readyrun/run-")).length,
-      1,
-    );
-  } finally {
-    await repo.cleanup();
-  }
-});
-
 test("a Run that lands nothing says no Run Branch was created, and names no ref that does not exist", async () => {
   const repo = await throwawayRepo();
   const out = capturing();

--- a/test/run-explicit-base.test.ts
+++ b/test/run-explicit-base.test.ts
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { test } from "node:test";
+import { defineConfig, run } from "../src/mod.ts";
+import { memoryTracker, recordingWorker } from "../src/testing/mod.ts";
+import { createWorkerAdapter } from "../src/worker-adapter.ts";
+import { ticket } from "./tracker-adapter-contract.ts";
+import {
+  commitRepoFiles,
+  commitWorkerWork,
+  git,
+  onDisk,
+  runBranch,
+  runBranches,
+  throwawayRepo,
+} from "./throwaway-repo.ts";
+
+const silent = { write(_chunk?: string) { return true; } };
+
+function capturing(): { chunks: string[]; stdout: { write(chunk: string): true } } {
+  const chunks: string[] = [];
+  return {
+    chunks,
+    stdout: {
+      write(chunk: string) {
+        chunks.push(chunk);
+        return true;
+      },
+    },
+  };
+}
+
+function frontier(ids: string[]) {
+  return memoryTracker({
+    tickets: ids.map((id) => ticket({ id })),
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+  });
+}
+
+// What the Worker found in the tree it was handed, which is the only place the
+// base is observable from inside a Ticket.
+function workerSeeing(
+  path: string,
+  seen: boolean[],
+) {
+  return createWorkerAdapter({
+    async spawn(request) {
+      seen.push(await onDisk(join(request.cwd, path)));
+      await commitWorkerWork(request);
+      return { exitCode: 0 };
+    },
+  });
+}
+
+test("--base cuts the first Ticket's Branch from the commit it names rather than from the checkout's HEAD", async () => {
+  const repo = await throwawayRepo();
+  const seen: boolean[] = [];
+  try {
+    const base = await git(repo.cwd, ["rev-parse", "HEAD"]);
+    await commitRepoFiles(repo.cwd, { "later.txt": "after the base\n" });
+    const moved = await git(repo.cwd, ["rev-parse", "HEAD"]);
+
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: frontier(["52"]),
+        worker: workerSeeing("later.txt", seen),
+        model: "composer-2",
+      }),
+      cap: 1,
+      base,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(seen, [false]);
+    const collected = await runBranch(repo.cwd);
+    await git(repo.cwd, ["merge-base", "--is-ancestor", base, collected]);
+    await assert.rejects(
+      git(repo.cwd, ["merge-base", "--is-ancestor", moved, collected]),
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a Run that used --base leaves the primary checkout's HEAD exactly where it was", async () => {
+  const repo = await throwawayRepo();
+  try {
+    const base = await git(repo.cwd, ["rev-parse", "HEAD"]);
+    await commitRepoFiles(repo.cwd, { "later.txt": "after the base\n" });
+    const head = await git(repo.cwd, ["rev-parse", "HEAD"]);
+
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: frontier(["52"]),
+        worker: createWorkerAdapter({
+          async spawn(request) {
+            await commitWorkerWork(request);
+            return { exitCode: 0 };
+          },
+        }),
+        model: "composer-2",
+      }),
+      cap: 1,
+      base,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(await git(repo.cwd, ["rev-parse", "HEAD"]), head);
+    assert.equal(await git(repo.cwd, ["rev-parse", "--abbrev-ref", "HEAD"]), "main");
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("--base starts a Run from a dirty primary checkout, and the warning that those changes reach no Worktree still stands", async () => {
+  const repo = await throwawayRepo();
+  const out = capturing();
+  try {
+    const base = await git(repo.cwd, ["rev-parse", "HEAD"]);
+    await writeFile(join(repo.cwd, "scratch.txt"), "not committed\n");
+
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: frontier(["52"]),
+        worker: recordingWorker({ exitCode: 0 }),
+        model: "composer-2",
+      }),
+      cap: 1,
+      base,
+      cwd: repo.cwd,
+      stdout: out.stdout,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.match(
+      out.chunks.join(""),
+      /^Warning: uncommitted changes in the primary checkout reach no Worktree$/m,
+    );
+    assert.equal((await runBranches(repo.cwd)).length, 1);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a --base git cannot resolve fails before any Ticket is claimed, and names the value that failed", async () => {
+  const repo = await throwawayRepo();
+  const worker = recordingWorker({ exitCode: 0 });
+  const tracker = frontier(["52"]);
+  const out = capturing();
+  try {
+    const exitCode = await run({
+      config: defineConfig({ tracker, worker, model: "composer-2" }),
+      cap: 1,
+      base: "no-such-ref",
+      cwd: repo.cwd,
+      stdout: out.stdout,
+    });
+
+    assert.equal(exitCode, 1);
+    assert.equal(worker.spawns.length, 0);
+    assert.deepEqual((await tracker.frontier()).map((item) => item.id), ["52"]);
+    assert.match(out.chunks.join(""), /Hard stop: failed at git: .*no-such-ref/);
+    assert.deepEqual(await runBranches(repo.cwd), []);
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a second Run based on the first Run's Run Branch hands its first Ticket a tree containing the first Run's landed work", async () => {
+  const repo = await throwawayRepo();
+  const seen: boolean[] = [];
+  try {
+    const first = await run({
+      config: defineConfig({
+        tracker: frontier(["52", "57"]),
+        worker: createWorkerAdapter({
+          async spawn(request) {
+            await commitWorkerWork(request);
+            return { exitCode: 0 };
+          },
+        }),
+        model: "composer-2",
+      }),
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+    assert.equal(first, 0);
+    const landedOn = await runBranch(repo.cwd);
+
+    const second = await run({
+      config: defineConfig({
+        tracker: frontier(["57"]),
+        worker: workerSeeing("ticket-52.txt", seen),
+        model: "composer-2",
+      }),
+      cap: 1,
+      base: landedOn,
+      cwd: repo.cwd,
+      stdout: silent,
+    });
+
+    assert.equal(second, 0);
+    assert.deepEqual(seen, [true]);
+  } finally {
+    await repo.cleanup();
+  }
+});

--- a/test/run-report-separation.test.ts
+++ b/test/run-report-separation.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { defineConfig, run } from "../src/mod.ts";
+import { memoryTracker } from "../src/testing/mod.ts";
+import { createWorkerAdapter } from "../src/worker-adapter.ts";
+import { ticket } from "./tracker-adapter-contract.ts";
+import { commitWorkerWork, throwawayRepo } from "./throwaway-repo.ts";
+
+// A Worker inherits stdout, so its output and ReadyRun's land on one stream in
+// the order they were written — and a Worker's last byte need not be a newline.
+// Writing to the Run's own stdout is that descriptor, from the test's side.
+const unterminated = "the Worker's last line, unterminated";
+
+function capturing(): { chunks: string[]; stdout: { write(chunk: string): true } } {
+  const chunks: string[] = [];
+  return {
+    chunks,
+    stdout: {
+      write(chunk: string) {
+        chunks.push(chunk);
+        return true;
+      },
+    },
+  };
+}
+
+function tracker() {
+  return memoryTracker({
+    tickets: [ticket({ id: "52" }), ticket({ id: "57" })],
+    ready: "unblocked",
+    labels: ["ready-for-agent"],
+  });
+}
+
+function workerEndingMidLine(
+  stdout: { write(chunk: string): true },
+  exitCode: number,
+) {
+  return createWorkerAdapter({
+    async spawn(request) {
+      if (exitCode === 0) {
+        await commitWorkerWork(request);
+      }
+      stdout.write(unterminated);
+      return { exitCode };
+    },
+  });
+}
+
+test("a clean stop's report starts a line of its own with a blank line above, whatever the Worker left on the stream", async () => {
+  const repo = await throwawayRepo();
+  const out = capturing();
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: tracker(),
+        worker: workerEndingMidLine(out.stdout, 0),
+        model: "composer-2",
+      }),
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: out.stdout,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.match(
+      out.chunks.join(""),
+      new RegExp(`${unterminated}\\n\\nRun complete: `),
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+test("a hard stop's report starts a line of its own with a blank line above, whatever the Worker left on the stream", async () => {
+  const repo = await throwawayRepo();
+  const out = capturing();
+  try {
+    const exitCode = await run({
+      config: defineConfig({
+        tracker: tracker(),
+        worker: workerEndingMidLine(out.stdout, 42),
+        model: "composer-2",
+      }),
+      cap: 1,
+      cwd: repo.cwd,
+      stdout: out.stdout,
+    });
+
+    assert.equal(exitCode, 1);
+    assert.match(
+      out.chunks.join(""),
+      new RegExp(`${unterminated}\\n\\nHard stop: `),
+    );
+  } finally {
+    await repo.cleanup();
+  }
+});
+
+// ADR 0032: off a TTY the output carries no control characters, so the
+// separation cannot be a cursor move or a rule — whitespace is the whole of it.
+test("the separation off a TTY is whitespace: no carriage return and no escape anywhere in either report's Run", async () => {
+  const repo = await throwawayRepo();
+  const clean = capturing();
+  const hard = capturing();
+  try {
+    assert.equal(
+      await run({
+        config: defineConfig({
+          tracker: tracker(),
+          worker: workerEndingMidLine(clean.stdout, 0),
+          model: "composer-2",
+        }),
+        cap: 1,
+        cwd: repo.cwd,
+        stdout: clean.stdout,
+      }),
+      0,
+    );
+    assert.equal(
+      await run({
+        config: defineConfig({
+          tracker: tracker(),
+          worker: workerEndingMidLine(hard.stdout, 42),
+          model: "composer-2",
+        }),
+        cap: 1,
+        cwd: repo.cwd,
+        stdout: hard.stdout,
+      }),
+      1,
+    );
+
+    for (const out of [clean, hard]) {
+      assert.doesNotMatch(out.chunks.join(""), /[\r\x1b]/);
+    }
+  } finally {
+    await repo.cleanup();
+  }
+});


### PR DESCRIPTION
## Why

Closes #107.

A **Run** always cut from whatever the **Consumer**'s checkout was on, so continuing a capped **Run** meant checking out a `readyrun/run-*` ref by hand — a git ritual ReadyRun would not name, which parks the **Consumer** on a ref they will forget they are on. A **Consumer** who did not know to do it silently handed the next **Worker** a tree missing the blockers it depends on. That is the failure a cap makes common rather than rare: the cap exists so a **Frontier** can be sliced (ADR 0005), which makes across-**Run** continuation the ordinary path. SpeechDeck hit it after `readyrun run --max 2`.

Separately, both end-of-**Run** reports were hard to find. A **Worker** inherits stdout, so a report's first line landed immediately after the coding CLI's output — appended to it outright when the **Worker**'s last byte was not a newline.

## What

`run` takes `--base <commit-ish>`, resolved to the commit the **Run Branch** collects onto and the first **Ticket**'s **Branch** is cut from. A clean stop on the cap that landed work ends by naming the invocation that continues from the **Run Branch** it just built. Both reports now begin after a blank line.

## How

`--base` never moves the primary checkout and never reads its working tree, so continuing does not require that checkout to have been clean and uncommitted work there still reaches no **Worktree** with the existing warning intact. The disclosure attributes the base to the flag and drops the "not the default branch" callout, which exists to catch a base nobody meant — a base the **Consumer** typed was meant (ADR 0034).

ADR 0033 is narrowed rather than overturned: still no push and no merge, but ReadyRun's own next invocation is its to explain. The separation is two newlines, shared by both reports, so off a TTY the output still carries no escape (ADR 0032).

## Workarounds

The acceptance criterion "a cap stop that landed nothing prints no continue invocation" is satisfied in code but not pinned by a test. `reason === "cap"` implies `landed === cap`, and a legal cap is at least 1, so the state is unreachable through the loop; the only lever is a `cap: 0` the CLI refuses and ADR 0005 calls illegal. Pinning report copy for a **Run** no **Consumer** can start seemed worse than leaving the guard commented, and the guard is kept because the line names the **Run Branch** as a base and so waits on that ref existing. That a report never names a `readyrun/run-*` ref git has no entry for stays pinned where it is reachable.

The separation writes two newlines unconditionally, so where ReadyRun itself wrote last there are two blank lines above the report rather than one. Knowing better would mean tracking whether a **Worker** has written since ReadyRun's last line, which is state for a cosmetic gain.

Made with [Cursor](https://cursor.com)